### PR TITLE
ENH: Add SimpleITK Resampling

### DIFF
--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -19,7 +19,7 @@ class RadiomicsFeaturesBase(object):
   def setBinWidth(self, binWidth):
     self.binWidth = binWidth
     
-  def setResampledPixelSpacing(self, resampledPixelSpacing, interpolator=2):
+  def setResampledPixelSpacing(self, resampledPixelSpacing, interpolator=sitk.sitkBSpline):
     self.resampledPixelSpacing = resampledPixelSpacing
     self.interpolator = interpolator
 

--- a/radiomics/preprocessing.py
+++ b/radiomics/preprocessing.py
@@ -43,15 +43,15 @@ class RadiomicsHelpers:
     return(matrix, matrixCoordinates)
 
   @staticmethod
-  def InterpolateImage(imageNode, resampledPixelSpacing, interpolator=2):
+  def InterpolateImage(imageNode, resampledPixelSpacing, interpolator=sitk.sitkBSpline):
     """Resamples image or label to the specified pixel spacing (The default interpolator is Bspline)
     
     'imageNode' is a SimpleITK Object, and 'resampledPixelSpacing' is the output pixel spacing. 
     Enumerator references for interpolator:
-    0 - Nearest Neighbor interpolation
-    1 - N-D linear
-    2 - Bspline of Order 3
-    3 - Gaussian
+    0 - sitkNearestNeighbor
+    1 - sitkLinear
+    2 - sitkBSpline
+    3 - sitkGaussian
     """ 
     rif = sitk.ResampleImageFilter()
     rif.SetOutputSpacing(resampledPixelSpacing)


### PR DESCRIPTION
SimpleITK 3D Resampling is done using BSpline of Order 3 Interpolation, whereas the baseline test data uses Cubic Interpolation. Testing the differences in features rankings across patients from a larger dataset would help assess the impact of the BSpline Interpolation. 
