### PR TITLE
ENH: pass processing arguments to the constructor

### DIFF
--- a/bin/helloRadiomics.py
+++ b/bin/helloRadiomics.py
@@ -2,15 +2,20 @@ from radiomics import firstorder, glcm, preprocessing, shape, rlgl
 import SimpleITK as sitk
 import sys, os
 
-#imageName = sys.argv[1]
-#maskName = sys.argv[2]
-
-testBinWidth = 25
+#testBinWidth = 25 this is the default bin size
 #testResampledPixelSpacing = (3,3,3) no resampling for now.
 
 dataDir = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + ".." + os.path.sep + "data"
-imageName = dataDir + os.path.sep + 'prostate_phantom-subvolume.nrrd'
-maskName = dataDir + os.path.sep + 'prostate_phantom_label-subvolume.nrrd'
+imageName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume.nrrd')
+maskName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume-label.nrrd')
+
+
+if not os.path.exists(imageName):
+  print 'Error: problem finding input image',imageName
+  os.exit()
+if not os.path.exists(maskName):
+  print 'Error: problem finding input image',maskName
+  os.exit()
 
 image = sitk.ReadImage(imageName)
 mask = sitk.ReadImage(maskName)
@@ -19,7 +24,6 @@ mask = sitk.ReadImage(maskName)
 # Show the first order feature calculations
 #
 firstOrderFeatures = firstorder.RadiomicsFirstOrder(image,mask)
-firstOrderFeatures.setBinWidth(testBinWidth)
 
 firstOrderFeatures.enableFeatureByName('MeanIntensity', True)
 # firstOrderFeatures.enableAllFeatures()
@@ -41,7 +45,6 @@ for (key,val) in firstOrderFeatures.featureValues.iteritems():
 # Show Shape features
 #
 shapeFeatures = shape.RadiomicsShape(image, mask)
-shapeFeatures.setBinWidth(testBinWidth)
 shapeFeatures.enableAllFeatures()
 
 print 'Will calculate the following Shape features: '
@@ -55,13 +58,13 @@ print 'done'
 
 print 'Calculated Shape features: '
 for (key,val) in shapeFeatures.featureValues.iteritems():
-  print '  ',key,':',val  
+  print '  ',key,':',val
 
 
 #
 # Show GLCM features
 #
-glcmFeatures = glcm.RadiomicsGLCM(image, mask, testBinWidth)
+glcmFeatures = glcm.RadiomicsGLCM(image, mask, binWidth=25)
 glcmFeatures.enableAllFeatures()
 
 print 'Will calculate the following GLCM features: '
@@ -80,7 +83,7 @@ for (key,val) in glcmFeatures.featureValues.iteritems():
 #
 # Show RLGL features
 #
-rlglFeatures = rlgl.RadiomicsRLGL(image, mask, 10)
+rlglFeatures = rlgl.RadiomicsRLGL(image, mask, binWidth=10)
 rlglFeatures.enableAllFeatures()
 
 print 'Will calculate the following RLGL features: '

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -1,7 +1,7 @@
 import SimpleITK as sitk
 
 class RadiomicsFeaturesBase(object):
-  def __init__(self, inputImage, inputMask):
+  def __init__(self, inputImage, inputMask, **kwargs):
     '''
     Initialization
 
@@ -12,23 +12,30 @@ class RadiomicsFeaturesBase(object):
     self.inputImage = inputImage
     self.inputMask = inputMask
 
+    self.binWidth = 25
+    self.resampledPixelSpacing = (,,) # no resampling
+    self.interpolator = sitk.sitkBSpline
+    self.padDistance = 5 # no padding
+    self.padFillValue = 0
+
+    for key,value in kwargs.iteritems():
+      if key == 'binWidth':
+        self.binWidth = value
+      elif key == 'resampledPixelSpacing':
+        self.resampledPixelSpacing = value
+      elif key == 'interpolator':
+        self.interpolator = value
+      elif key == 'padDistance':
+        self.padDistance = value
+      elif key == 'padFillValue':
+        self.padFillValue = value
+      else:
+        print 'Warning: unknown parameter:',key
+
     # all features are disabled by default
     self.disableAllFeatures()
 
     self.featureNames = self.getFeatureNames()
-
-  def setBinWidth(self, binWidth):
-    self.binWidth = binWidth
-    
-  def setResampledPixelSpacing(self, resampledPixelSpacing, interpolator=sitk.sitkBSpline):
-    self.resampledPixelSpacing = resampledPixelSpacing
-    self.interpolator = interpolator
-
-  def setPadDistance(self, padDistance):
-    self.padDistance = padDistance
-
-  def setPadFillValue(self, padFillValue):
-    self.padFillValue = padFillValue
 
   def enableFeatureByName(self, featureName, enable=True):
     if not featureName in self.featureNames:

--- a/radiomics/firstorder.py
+++ b/radiomics/firstorder.py
@@ -5,8 +5,8 @@ import SimpleITK as sitk
 
 class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
 
-  def __init__(self, inputImage, inputMask):
-    super(RadiomicsFirstOrder,self).__init__(inputImage,inputMask)
+  def __init__(self, inputImage, inputMask, **kwargs):
+    super(RadiomicsFirstOrder,self).__init__(inputImage,inputMask,**kwargs)
 
     self.pixelSpacing = inputImage.GetSpacing()
 

--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -5,12 +5,11 @@ import SimpleITK as sitk
 
 class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   """GLCM feature calculation."""
-  def __init__(self, inputImage, inputMask, binWidth=25):
-    super(RadiomicsGLCM,self).__init__(inputImage, inputMask)
+  def __init__(self, inputImage, inputMask, **kwargs):
+    super(RadiomicsGLCM,self).__init__(inputImage, inputMask, **kwargs)
 
     self.imageArray = sitk.GetArrayFromImage(inputImage)
     self.maskArray = sitk.GetArrayFromImage(inputMask)
-    self.binWidth = binWidth
     
     (self.matrix, self.matrixCoordinates) = \
       preprocessing.RadiomicsHelpers.padTumorMaskToCube(self.imageArray,self.maskArray)
@@ -30,9 +29,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def calculateGLCM(self, distances, angles):
     """
     Compute 13 GLCM matrices for the input image for every direction in 3D.
-    
+
     (13 GLCMs for each neighboring voxel from a reference voxel centered in a 3x3 cube)
-    """      
+    """
     maxrows = self.matrix.shape[2]
     maxcols = self.matrix.shape[1]
     maxheight = self.matrix.shape[0]
@@ -63,12 +62,12 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
 
   def createGLCM(self):
     """
-    Generate container for GLCM Matrices: P_glcm as an array of shape: (i,j,gamma,a) 
-    
-    i/j = total gray-level bins for image array, 
-    gamma = 1 (distance in voxels), 
+    Generate container for GLCM Matrices: P_glcm as an array of shape: (i,j,gamma,a)
+
+    i/j = total gray-level bins for image array,
+    gamma = 1 (distance in voxels),
     a = 1...13 (directions in 3D)
-    """        
+    """
     Ng = self.coefficients['Ng']
 
     distances=numpy.array([1])
@@ -94,7 +93,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
 
   # check if ivector and jvector can be replaced
   def calculateCoefficients(self):
-    """Calculate and fill in the coefficients dict"""       
+    """Calculate and fill in the coefficients dict"""
     Ng = self.coefficients['Ng']
     eps = numpy.spacing(1)
 
@@ -179,10 +178,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getAutocorrelationFeatureValue(self):
     """
     Using the i and j arrays, calculate and return the mean Autocorrelation for all 13 GLCMs.
-    
-    Autocorrelation is a measure of the magnitude of the 
+
+    Autocorrelation is a measure of the magnitude of the
     fineness and coarseness of texture.
-    """     
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     ac = numpy.sum(numpy.sum(self.P_glcm * (i*j)[:,:,None,None], 0 ), 0 )
@@ -191,11 +190,11 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getClusterProminenceFeatureValue(self):
     """
     Using coefficients i, j, ux, uy, calculate and return the mean Cluster Prominence for all 13 GLCMs.
-    
-    Cluster Prominence is a measure of the skewness and asymmetry of the GLCM. 
-    A higher values implies more asymmetry about the mean while a lower value 
+
+    Cluster Prominence is a measure of the skewness and asymmetry of the GLCM.
+    A higher values implies more asymmetry about the mean while a lower value
     indicates a peak near the mean value and less variation about the mean.
-    """     
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     ux = self.coefficients['ux']
@@ -206,10 +205,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getClusterShadeFeatureValue(self):
     """
     Using coefficients i, j, ux, uy, calculate and return the mean Cluster Shade for all 13 GLCMs.
-    
-    Cluster Shade is a measure of the skewness and uniformity of the GLCM. 
+
+    Cluster Shade is a measure of the skewness and uniformity of the GLCM.
     A higher cluster shade implies greater asymmetry about the mean.
-    """       
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     ux = self.coefficients['ux']
@@ -220,9 +219,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getClusterTendencyFeatureValue(self):
     """
     Using coefficients i, j, ux, uy, calculate and return the mean Cluster Tendency for all 13 GLCMs.
-    
+
     Cluster Tendency is a measure of groupings of voxels with similar gray-level values.
-    """       
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     ux = self.coefficients['ux']
@@ -233,11 +232,11 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getContrastFeatureValue(self):
     """
     Using coefficients i, j, calculate and return the mean Contrast for all 13 GLCMs.
-    
-    Contrast is a measure of the local intensity variation, favoring P(i,j) 
+
+    Contrast is a measure of the local intensity variation, favoring P(i,j)
     values away from the diagonal (i != j). A larger value correlates with
     a greater disparity in intensity values among neighboring voxels.
-    """      
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     cont = numpy.sum( numpy.sum( (self.P_glcm * ((numpy.abs(i-j))[:,:,None,None]**2)), 0 ), 0 )
@@ -246,10 +245,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getCorrelationFeatureValue(self):
     """
     Using coefficients i, j, ux, uy, sigx, sigy, calculate and return the mean Correlation value for all 13 GLCMs.
-    
-    Correlation is a value between 0 (uncorrelated) and 1 (perfectly correlated) showing the 
+
+    Correlation is a value between 0 (uncorrelated) and 1 (perfectly correlated) showing the
     linear dependency of gray level values to their respective voxels in the GLCM.
-    """       
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     ux = self.coefficients['ux']
@@ -263,10 +262,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getDifferenceEntropyFeatureValue(self):
     """
     Using coefficients pxSuby, eps, calculate and return the mean Difference Entropy for all 13 GLCMs.
-    
-    Difference Entropy is a measure of the randomness/variability 
+
+    Difference Entropy is a measure of the randomness/variability
     in neighborhood intensity value differences.
-    """       
+    """
     pxSuby = self.coefficients['pxSuby']
     eps = self.coefficients['eps']
     difent = (-1) * numpy.sum( (pxSuby*numpy.log(pxSuby+eps)), 0 )
@@ -275,11 +274,11 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getDissimilarityFeatureValue(self):
     """
     Using coefficients i, j, calculate and return the mean Dissimilarity for all 13 GLCMs.
-    
-    Dissimilarity is a measure of local intensity variation. A larger 
-    value correlates with a greater disparity in intensity values 
-    among neighboring voxels. 
-    """       
+
+    Dissimilarity is a measure of local intensity variation. A larger
+    value correlates with a greater disparity in intensity values
+    among neighboring voxels.
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     dis = numpy.sum( numpy.sum( (self.P_glcm * (numpy.abs(i-j))[:,:,None,None]), 0 ), 0 )
@@ -288,21 +287,21 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getEnergyFeatureValue(self):
     """
     Using P_glcm, calculate and return the mean Energy for all 13 GLCMs.
-    
-    Energy (or Angular Second Moment)is a measure of homogeneous patterns 
-    in the image. A greater Energy implies that there are more instances 
-    of intensity value pairs in the image that neighbor each other at 
+
+    Energy (or Angular Second Moment)is a measure of homogeneous patterns
+    in the image. A greater Energy implies that there are more instances
+    of intensity value pairs in the image that neighbor each other at
     higher frequencies.
-    """       
+    """
     ene = numpy.sum( numpy.sum( (self.P_glcm**2), 0), 0 )
     return (ene.mean())
 
   def getEntropyFeatureValue(self):
     """
     Using coefficients eps, calculate and return the mean Entropy for all 13 GLCMs.
-    
+
     Entropy is a measure of the randomness/variability in neighborhood intensity values.
-    """     
+    """
     eps = self.coefficients['eps']
     ent = (-1) * numpy.sum( numpy.sum( (self.P_glcm * numpy.log(self.P_glcm+eps)), 0), 0)
     return (ent.mean())
@@ -310,9 +309,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getHomogeneity1FeatureValue(self):
     """
     Using coefficients i, j, calculate and return the mean Homogeneity 1 for all 13 GLCMs.
-    
+
     Homogeneity 1 is a measure of the similarity in intensity values for neighboring voxels.
-    """   
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     homo1 = numpy.sum( numpy.sum( (self.P_glcm / (1 + (numpy.abs(i-j))[:,:,None,None])), 0 ), 0 )
@@ -321,17 +320,17 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getHomogeneity2FeatureValue(self):
     """
     Using coefficients i, j, calculate and return the mean Homogeneity 2 for all 13 GLCMs.
-    
+
     Homogeneity 2 is a measure of the similarity in intensity values
     for neighboring voxels.
-    """     
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     homo2 = numpy.sum( numpy.sum( (self.P_glcm / (1 + (numpy.abs(i-j))[:,:,None,None]**2)), 0 ), 0 )
     return (homo2.mean())
 
   def getImc1FeatureValue(self):
-    """Using coefficients HX, HY, HXY, HXY1, HXY2, calculate and return the mean IMC1 for all 13 GLCMs."""       
+    """Using coefficients HX, HY, HXY, HXY1, HXY2, calculate and return the mean IMC1 for all 13 GLCMs."""
     HX = self.coefficients['HX']
     HY = self.coefficients['HY']
     HXY = self.coefficients['HXY']
@@ -343,9 +342,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getImc2FeatureValue(self):
     """
     Using coefficients HXY, HXY2, calculate and return the mean IMC2 for all 13 GLCMs.
-    
+
     NOT IMPLEMENTED
-    """     
+    """
     # Produces Error
     HXY = self.coefficients['HXY']
     HXY2 = self.coefficients['HXY2']
@@ -365,13 +364,13 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getIdmnFeatureValue(self):
     """
     Using coefficients i, j, Ng, calculate and return the mean IDMN for all 13 GLCMs.
-    
-    IDMN is a measure of the local homogeneity of an image. IDMN weights 
-    are the inverse of the Contrast weights (decreasing exponentially from 
-    the diagonal i=j in the GLCM). Unlike Homogeneity2, IDMN normalizes the 
-    square of the difference between neighboring intensity values by 
+
+    IDMN is a measure of the local homogeneity of an image. IDMN weights
+    are the inverse of the Contrast weights (decreasing exponentially from
+    the diagonal i=j in the GLCM). Unlike Homogeneity2, IDMN normalizes the
+    square of the difference between neighboring intensity values by
     dividing over the square of the total number of discrete intensity values.
-    """       
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     Ng = self.coefficients['Ng']
@@ -381,11 +380,11 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getIdnFeatureValue(self):
     """
     Using coefficients i, j, Ng, calculate and return the mean IDN for all 13 GLCMs.
-    
-    IDN is another measure of the local homogeneity of an image. Unlike 
+
+    IDN is another measure of the local homogeneity of an image. Unlike
     Homogeneity1, IDN normalizes the difference between the neighboring
     intensity values by dividing over the total number of discrete intensity values.
-    """     
+    """
     i = self.coefficients['i']
     j = self.coefficients['j']
     Ng = self.coefficients['Ng']
@@ -393,7 +392,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     return (idn.mean())
 
   def getInverseVarianceFeatureValue(self):
-    """Using the i, j, Ng coeffients, calculate and return the mean Inverse Variance for all 13 GLCMs."""    
+    """Using the i, j, Ng coeffients, calculate and return the mean Inverse Variance for all 13 GLCMs."""
     i = self.coefficients['i']
     j = self.coefficients['j']
     Ng = self.coefficients['Ng']
@@ -405,21 +404,21 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getMaximumProbabilityFeatureValue(self):
     """
     Using P_glcm, calculate and return the mean Maximum Probability for all 13 GLCMs.
-    
-    Maximum Probability is occurrences of the most predominant pair of 
+
+    Maximum Probability is occurrences of the most predominant pair of
     neighboring intensity values.
-    """      
+    """
     maxprob = self.P_glcm.max(0).max(0)
     return (maxprob.mean())
 
   def getSumAverageFeatureValue(self):
     """
     Using coefficients pxAddy, kValuesSum, calculate and return the mean Sum Average for all 13 GLCMs.
-    
-    Sum Average measures the relationship between occurrences of pairs 
+
+    Sum Average measures the relationship between occurrences of pairs
     with lower intensity values and occurrences of pairs with higher intensity
     values.
-    """       
+    """
     pxAddy = self.coefficients['pxAddy']
     kValuesSum = self.coefficients['kValuesSum']
     sumavg =  numpy.sum( (kValuesSum[:,None,None]*pxAddy), 0 )
@@ -428,9 +427,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getSumEntropyFeatureValue(self):
     """
     Using coefficients pxAddy, eps, calculate and return the mean Sum Entropy for all 13 GLCMs.
-    
-    Sum Entropy is a sum of neighborhood intensity value differences. 
-    """      
+
+    Sum Entropy is a sum of neighborhood intensity value differences.
+    """
     pxAddy = self.coefficients['pxAddy']
     eps = self.coefficients['eps']
     sumentr = (-1) * numpy.sum( (pxAddy * numpy.log(pxAddy+eps)), 0 )
@@ -439,10 +438,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getSumVarianceFeatureValue(self):
     """
     Using coefficients pxAddy, kValuesSum, calculate and return the mean Sum Variance for all 13 GLCMs.
-    
-    Sum Variance is a measure of heterogeneity that places higher weights on 
+
+    Sum Variance is a measure of heterogeneity that places higher weights on
     neighboring intensity level pairs that deviate more from the mean.
-    """ 
+    """
     pxAddy = self.coefficients['pxAddy']
     kValuesSum = self.coefficients['kValuesSum']
     sumvar = numpy.sum( (pxAddy*((kValuesSum[:,None,None] - kValuesSum[:,None,None]*pxAddy)**2)), 0 )
@@ -451,10 +450,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def getSumSquaresFeatureValue(self):
     """
     Using coefficients j, u, calculate and return the mean um of Squares (Variance) for all 13 GLCMs.
-    
+
     Sum of Squares or Variance is a measure in the distribution of neigboring
     intensity level pairs about the mean intensity level in the GLCM.
-    """  
+    """
     j = self.coefficients['j']
     u = self.coefficients['u']
     # Also known as Variance

--- a/radiomics/rlgl.py
+++ b/radiomics/rlgl.py
@@ -5,12 +5,11 @@ from radiomics import base, preprocessing
 
 class RadiomicsRLGL(base.RadiomicsFeaturesBase):
   """RLGL feature calculation."""
-  def __init__(self, inputImage, inputMask, binWidth):
-      super(RadiomicsRLGL,self).__init__(inputImage, inputMask)
+  def __init__(self, inputImage, inputMask, **kwargs):
+      super(RadiomicsRLGL,self).__init__(inputImage, inputMask, **kwargs)
 
       self.imageArray = sitk.GetArrayFromImage(inputImage)
       self.maskArray = sitk.GetArrayFromImage(inputMask)
-      self.binWidth = binWidth
 
       (self.matrix, self.matrixCoordinates) = \
         preprocessing.RadiomicsHelpers.padTumorMaskToCube(self.imageArray,self.maskArray)

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -6,18 +6,18 @@ import SimpleITK as sitk
 
 class RadiomicsShape(base.RadiomicsFeaturesBase):
 
-  def __init__(self, inputImage, inputMask):
-    super(RadiomicsShape,self).__init__(inputImage,inputMask)
+  def __init__(self, inputImage, inputMask, **kwargs):
+    super(RadiomicsShape,self).__init__(inputImage,inputMask, **kwargs)
 
     self.pixelSpacing = inputImage.GetSpacing()
     self.cubicMMPerVoxel = reduce(lambda x,y: x*y , self.pixelSpacing)
-    
+
     #self.featureNames = self.getFeatureNames()
 
     self.imageArray = sitk.GetArrayFromImage(inputImage)
     self.maskArray = sitk.GetArrayFromImage(inputMask)
-        
-    # Generate a cuboid matrix of the tumor region and pad by 10 voxels in three directions 
+
+    # Generate a cuboid matrix of the tumor region and pad by 10 voxels in three directions
     # for surface area calculation
     (self.matrix, self.matrixCoordinates) = \
       preprocessing.RadiomicsHelpers.padTumorMaskToCube(self.imageArray, self.maskArray, padDistance=10)
@@ -32,7 +32,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     #  self.enabledFeatures[f] = True
 
     # TODO: add an option to instantiate the class that reuses initialization
-       
+
   def getVolumeFeatureValue(self):
     """Calculate the volume of the tumor region in cubic millimeters."""
     return (self.matrix[self.matrixCoordinates].size * self.cubicMMPerVoxel)
@@ -45,79 +45,79 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     xy = x*y
     voxelTotalSA = (2*xy + 2*xz + 2*yz)
     totalSA = self.targetVoxelArray.size * voxelTotalSA
-    
+
     # in matrixCoordinates:
     # i corresponds to height (z)
     # j corresponds to vertical (y)
     # k corresponds to horizontal (x)
-    
+
     i, j, k = 0, 0, 0
-    surfaceArea = 0   
+    surfaceArea = 0
     for voxel in xrange(0, self.targetVoxelArray.size):
-      i, j, k = self.matrixCoordinates[0][voxel], self.matrixCoordinates[1][voxel], self.matrixCoordinates[2][voxel]      
+      i, j, k = self.matrixCoordinates[0][voxel], self.matrixCoordinates[1][voxel], self.matrixCoordinates[2][voxel]
       fxy = (numpy.array([ self.matrix[i+1,j,k], self.matrix[i-1,j,k] ]) == 0) # evaluate to 1 if true, 0 if false
       fyz = (numpy.array([ self.matrix[i,j+1,k], self.matrix[i,j-1,k] ]) == 0) # evaluate to 1 if true, 0 if false
-      fxz = (numpy.array([ self.matrix[i,j,k+1], self.matrix[i,j,k-1] ]) == 0) # evaluate to 1 if true, 0 if false  
-      surface = (numpy.sum(fxz) * xz) + (numpy.sum(fyz) * yz) + (numpy.sum(fxy) * xy)     
+      fxz = (numpy.array([ self.matrix[i,j,k+1], self.matrix[i,j,k-1] ]) == 0) # evaluate to 1 if true, 0 if false
+      surface = (numpy.sum(fxz) * xz) + (numpy.sum(fyz) * yz) + (numpy.sum(fxy) * xy)
       surfaceArea += surface
-      
+
     return (surfaceArea)
-     
+
   def getSurfaceVolumeRatioFeatureValue(self):
     """Calculate the surface area to volume ratio of the tumor region"""
     return (self.SurfaceArea/self.Volume)
-           
+
   def getCompactness1FeatureValue(self):
     """
     Calculate the compactness (1) of the tumor region.
-    
+
     Compactness 1 is a measure of how compact the shape of the tumor is relative to a sphere (most compact).
     """
     return ( (self.Volume) / ((self.SurfaceArea)**(2.0/3.0) * numpy.sqrt(numpy.pi)) )
-     
+
   def getCompactness2FeatureValue(self):
     """
     Calculate the Compactness (2) of the tumor region.
-    
+
     Compactness 2 is a measure of how compact the shape of the tumor is relative to a sphere (most compact).
-    """  
-    return ((36.0 * numpy.pi) * ((self.Volume)**2.0)/((self.SurfaceArea)**3.0)) 
+    """
+    return ((36.0 * numpy.pi) * ((self.Volume)**2.0)/((self.SurfaceArea)**3.0))
 
   def getMaximum3DDiameterFeatureValue(self):
-    """Calculate the largest pairwise euclidean distance between tumor surface voxels"""   
+    """Calculate the largest pairwise euclidean distance between tumor surface voxels"""
     x, y, z = self.pixelSpacing
-    
+
     minBounds = numpy.array([numpy.min(self.matrixCoordinates[0]), numpy.min(self.matrixCoordinates[1]), numpy.min(self.matrixCoordinates[2])])
     maxBounds = numpy.array([numpy.max(self.matrixCoordinates[0]), numpy.max(self.matrixCoordinates[1]), numpy.max(self.matrixCoordinates[2])])
-    
+
     a = numpy.array(zip(*self.matrixCoordinates))
     edgeVoxelsMinCoords = numpy.vstack([a[a[:,0]==minBounds[0]], a[a[:,1]==minBounds[1]], a[a[:,2]==minBounds[2]]]) * [z,y,x]
     edgeVoxelsMaxCoords = numpy.vstack([(a[a[:,0]==maxBounds[0]]+1), (a[a[:,1]==maxBounds[1]]+1), (a[a[:,2]==maxBounds[2]]+1)]) * [z,y,x]
-    
-    maxDiameter = 1   
+
+    maxDiameter = 1
     for voxel1 in edgeVoxelsMaxCoords:
       voxelDistances = numpy.sqrt(numpy.sum((edgeVoxelsMinCoords-voxel1)**2))
-      if voxelDistances.max() > maxDiameter: 
+      if voxelDistances.max() > maxDiameter:
         maxDiameter = voxelDistances.max()
-      
-    return(maxDiameter)     
-      
+
+    return(maxDiameter)
+
   def getSphericalDisproportionFeatureValue(self):
     """
     Calculate the Spherical Disproportion of the tumor region.
-    
+
     Spherical Disproportion is the ratio of the surface area of the
-    tumor region to the surface area of a sphere with the same 
+    tumor region to the surface area of a sphere with the same
     volume as the tumor region.
-    """ 
-    R = ( (3.0*self.Volume)/(4.0*numpy.pi) )**(1.0/3.0)   
+    """
+    R = ( (3.0*self.Volume)/(4.0*numpy.pi) )**(1.0/3.0)
     return ( (self.SurfaceArea)/(4.0*numpy.pi*(R**2.0)) )
-      
+
   def getSphericityFeatureValue(self):
     """
     Calculate the Sphericity of the tumor region.
-    
+
     Sphericity is a measure of the roundness of the shape of the tumor region
     relative to a sphere. This is another measure of the compactness of a tumor.
-    """   
-    return ( ((numpy.pi)**(1.0/3.0) * (6.0 * self.Volume)**(2.0/3.0)) / (self.SurfaceArea) ) 
+    """
+    return ( ((numpy.pi)**(1.0/3.0) * (6.0 * self.Volume)**(2.0/3.0)) / (self.SurfaceArea) )


### PR DESCRIPTION
Setting some of the processing parameters via method calls (e.g., binwidth)
does not make sense, since they need to be applied at the initialization time.
Those arguments are now passed via **kwargs, and are passed along to the base
class for initialization of the class variables.

Resolves #16
