### PR TITLE
Fix CircleCI badge rendering using a scoped token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Circle CI](https://circleci.com/gh/Radiomics/pyradiomics.svg?style=svg)](https://circleci.com/gh/Radiomics/pyradiomics)
+[![Circle CI](https://circleci.com/gh/Radiomics/pyradiomics.svg?style=svg&circle-token=a4748cf0de5fad2c12bc93a485282378551c3584)](https://circleci.com/gh/Radiomics/pyradiomics)
 
 Unless otherwise stated, the features in the this module have been derived from the following publication:
 


### PR DESCRIPTION
For private project, status badges have to be associated with a
scoped "status" token.

See https://circleci.com/docs/status-badges

The steps to create the token were:

1) Create a `status` token

![pyradiomics-circleci-badge](https://cloud.githubusercontent.com/assets/219043/12803913/527b974a-cabc-11e5-92f1-c98090035694.png)

2) Go to "status" badge

![pyradiomics-status-badge](https://cloud.githubusercontent.com/assets/219043/12803932/7d8df356-cabc-11e5-9a65-d08365afba85.png)
