### PR TITLE
ENH: use nose_parameterized for tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ dependencies:
   pre:
     - pip install numpy
     - pip install -f http://www.simpleitk.org/SimpleITK/resources/software.html SimpleITK
+    - pip install nose-parameterized
 test:
   override:
     - nosetests --logging-level=DEBUG --verbosity=3 tests

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -7,6 +7,7 @@ from testUtils import RadiomicsTestUtils
 import SimpleITK as sitk
 import sys, os
 import logging
+from nose_parameterized import parameterized
 
 def setup_module(module):
     # runs before anything in this file
@@ -30,44 +31,42 @@ class TestDocStrings:
         # run after any methods in this class
         print ("") # this is to get a newline after the dots
 
+    def generate_scenarios(featureClass):
+      logging.info('generate_scenarios %s', featureClass)
+      featureNames = featureClass.getFeatureNames()
+      for f in featureNames:
+        yield (f)
 
-    def test_firstOrder(self):
-       logging.info("Instantiating first order features.")
-       self.features = firstorder.RadiomicsFirstOrder(None, None)
-       self.featureNames = firstorder.RadiomicsFirstOrder.getFeatureNames()
-       for f in self.featureNames:
-           logging.info('  %s', f)
-           doc = eval('self.features.get'+f+'FeatureValue.__doc__')
-           logging.info('%s', doc)
-           assert(doc != None)
+    @parameterized.expand(generate_scenarios(firstorder.RadiomicsFirstOrder))
+    def test_firstOrder(self, featureName):
+      logging.info('%s', featureName)
+      features = firstorder.RadiomicsFirstOrder(None, None)
+      doc = eval('features.get'+featureName+'FeatureValue.__doc__')
+      logging.info('%s', doc)
+      assert(doc != None)
 
 
-    def test_glcm(self):
-       logging.info("Instantiating GLCM features.")
-       self.features = glcm.RadiomicsGLCM(None, None)
-       self.featureNames = glcm.RadiomicsGLCM.getFeatureNames()
-       for f in self.featureNames:
-           logging.info('  %s', f)
-           doc = eval('self.features.get'+f+'FeatureValue.__doc__')
-           logging.info('%s', doc)
-           assert(doc != None)
+    @parameterized.expand(generate_scenarios(glcm.RadiomicsGLCM))
+    def test_glcm(self, featureName):
+      logging.info('%s', featureName)
+      features = glcm.RadiomicsGLCM(None, None)
+      doc = eval('features.get'+featureName+'FeatureValue.__doc__')
+      logging.info('%s', doc)
+      assert(doc != None)
 
-    def test_rlgl(self):
-       logging.info("Instantiating RLGL features.")
-       self.features = rlgl.RadiomicsRLGL(None, None)
-       self.featureNames = rlgl.RadiomicsRLGL.getFeatureNames()
-       for f in self.featureNames:
-           logging.info('  %s', f)
-           doc = eval('self.features.get'+f+'FeatureValue.__doc__')
-           logging.info('%s', doc)
-           assert(doc != None)
 
-    def test_shape(self):
-       logging.info("Instantiating Shape features.")
-       self.features = shape.RadiomicsShape(None, None)
-       self.featureNames = shape.RadiomicsShape.getFeatureNames()
-       for f in self.featureNames:
-           logging.info('  %s', f)
-           doc = eval('self.features.get'+f+'FeatureValue.__doc__')
-           logging.info('%s', doc)
-           assert(doc != None)
+    @parameterized.expand(generate_scenarios(rlgl.RadiomicsRLGL))
+    def test_rlgl(self, featureName):
+      logging.info('%s', featureName)
+      features = rlgl.RadiomicsRLGL(None, None)
+      doc = eval('features.get'+featureName+'FeatureValue.__doc__')
+      logging.info('%s', doc)
+      assert(doc != None)
+
+    @parameterized.expand(generate_scenarios(shape.RadiomicsShape))
+    def test_shape(self, featureName):
+       logging.info('%s', featureName)
+       features = shape.RadiomicsShape(None, None)
+       doc = eval('features.get'+featureName+'FeatureValue.__doc__')
+       logging.info('%s', doc)
+       assert(doc != None)

--- a/tests/test_firstorder.py
+++ b/tests/test_firstorder.py
@@ -7,6 +7,7 @@ from testUtils import RadiomicsTestUtils
 import SimpleITK as sitk
 import sys, os
 import logging
+from nose_parameterized import parameterized
 
 def setup_module(module):
     # runs before anything in this file
@@ -48,122 +49,17 @@ class TestFirstOrder:
         # run after any methods in this class
         print ("") # this is to get a newline after the dots
 
-    def test_energy(self):
-        testString = 'Energy'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    def generate_scenarios():
+      # get the feature names
+      featureNames = firstorder.RadiomicsFirstOrder.getFeatureNames()
+      logging.info('generate_scenarios: featureNames = %s', featureNames)
+      for f in featureNames:
+        yield (f)
 
-    def test_totalEnergy(self):
-        testString = 'TotalEnergy'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_entropy(self):
-        testString = 'Entropy'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_minimum(self):
-        testString = 'Minimum'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_maximum(self):
-        testString = 'Maximum'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_mean(self):
-        testString = 'Mean'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_median(self):
-        testString = 'Median'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_range(self):
-        testString = 'Range'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_meanDeviation(self):
-        testString = 'MeanDeviation'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_rootMeanSquared(self):
-        testString = 'RootMeanSquared'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_standardDeviation(self):
-        testString = 'StandardDeviation'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_skewness(self):
-        testString = 'Skewness'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_kurtosis(self):
-        testString = 'Kurtosis'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_variance(self):
-        testString = 'Variance'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_uniformity(self):
-        testString = 'Uniformity'
-        logging.info('Test %s', testString)
-        self.firstOrderFeatures.enableFeatureByName(testString)
-        self.firstOrderFeatures.calculateFeatures()
-        val = self.firstOrderFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    @parameterized.expand(generate_scenarios())
+    def test_scenario(self, featureName):
+      logging.info('test_scenario: featureName = %s', featureName)
+      self.firstOrderFeatures.enableFeatureByName(featureName)
+      self.firstOrderFeatures.calculateFeatures()
+      val = self.firstOrderFeatures.featureValues[featureName]
+      self.testUtils.checkResult(featureName, val)

--- a/tests/test_glcm.py
+++ b/tests/test_glcm.py
@@ -2,11 +2,12 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_glcm.py
 
-from radiomics import firstorder, glcm, imageoperations
+from radiomics import glcm, imageoperations
 from testUtils import RadiomicsTestUtils
 import SimpleITK as sitk
 import sys, os
 import logging
+from nose_parameterized import parameterized
 
 def setup_module(module):
     # run before anything in this file
@@ -48,170 +49,17 @@ class TestGLCM:
         # run after any methods in this class
         print ("") # this is to get a newline after the dots
 
-    def test_autocorrelation(self):
-        testString = 'Autocorrelation'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    def generate_scenarios():
+      # get the feature names
+      featureNames = glcm.RadiomicsGLCM.getFeatureNames()
+      logging.info('generate_scenarios: featureNames = %s', featureNames)
+      for f in featureNames:
+        yield (f)
 
-    def test_clusterProminence(self):
-        testString = 'ClusterProminence'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_clusterShade(self):
-        testString = 'ClusterShade'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_clusterTendency(self):
-        testString = 'ClusterTendency'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_contrast(self):
-        testString = 'Contrast'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_correlation(self):
-        testString = 'Correlation'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_differenceEntropy(self):
-        testString = 'DifferenceEntropy'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_dissimilarity(self):
-        testString = 'Dissimilarity'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_energy(self):
-        testString = 'Energy'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_entropy(self):
-        testString = 'Entropy'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_homogeneity1(self):
-        testString = 'Homogeneity1'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_homogeneity2(self):
-        testString = 'Homogeneity2'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_imc1(self):
-        testString = 'Imc1'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_imc2(self):
-        testString = 'Imc2'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_idmn(self):
-        testString = 'Idmn'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_idn(self):
-        testString = 'Idn'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_inverseVariance(self):
-        testString = 'InverseVariance'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_maximumProbability(self):
-        testString = 'MaximumProbability'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_sumAverage(self):
-        testString = 'SumAverage'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_sumVariance(self):
-        testString = 'SumVariance'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_sumSquares(self):
-        testString = 'SumSquares'
-        logging.info('Test %s', testString)
-        self.glcmFeatures.enableFeatureByName(testString)
-        self.glcmFeatures.calculateFeatures()
-        val = self.glcmFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    @parameterized.expand(generate_scenarios())
+    def test_scenario(self, featureName):
+      logging.info('test_scenario: featureName = %s', featureName)
+      self.glcmFeatures.enableFeatureByName(featureName)
+      self.glcmFeatures.calculateFeatures()
+      val = self.glcmFeatures.featureValues[featureName]
+      self.testUtils.checkResult(featureName, val)

--- a/tests/test_rlgl.py
+++ b/tests/test_rlgl.py
@@ -3,10 +3,11 @@
 # nosetests --nocapture -v tests/test_rlgl.py
 
 import SimpleITK as sitk
-from radiomics import firstorder, rlgl
+from radiomics import rlgl
 from testUtils import RadiomicsTestUtils
 import sys, os
 import logging
+from nose_parameterized import parameterized
 
 def setup_module(module):
     # run before anything in this file"
@@ -49,82 +50,17 @@ class TestRLGL:
         # after any methods in this class
         print ("") # this is to get a newline after the dots
 
-    def test_shortRunEmphasis(self):
-        testString = 'ShortRunEmphasis'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    def generate_scenarios():
+      # get the feature names
+      featureNames = rlgl.RadiomicsRLGL.getFeatureNames()
+      logging.info('generate_scenarios: featureNames = %s', featureNames)
+      for f in featureNames:
+        yield (f)
 
-    def test_longRunEmphasis(self):
-        testString = 'LongRunEmphasis'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_grayLevelNonUniformity(self):
-        testString = 'GrayLevelNonUniformity'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_runLengthNonUniformity(self):
-        testString = 'RunLengthNonUniformity'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_runPercentage(self):
-        testString = 'RunPercentage'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_lowGrayLevelRunEmphasis(self):
-        testString = 'LowGrayLevelRunEmphasis'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_highGrayLevelRunEmphasis(self):
-        testString = 'HighGrayLevelRunEmphasis'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_shortRunHighGrayLevelEmphasis(self):
-        testString = 'ShortRunHighGrayLevelEmphasis'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_longRunLowGrayLevelEmphasis(self):
-        testString = 'LongRunLowGrayLevelEmphasis'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_longRunHighGrayLevelEmphasis(self):
-        testString = 'LongRunHighGrayLevelEmphasis'
-        logging.info('Test %s', testString)
-        self.rlglFeatures.enableFeatureByName(testString)
-        self.rlglFeatures.calculateFeatures()
-        val = self.rlglFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    @parameterized.expand(generate_scenarios())
+    def test_scenario(self, featureName):
+      logging.info('test_scenario: featureName = %s', featureName)
+      self.rlglFeatures.enableFeatureByName(featureName)
+      self.rlglFeatures.calculateFeatures()
+      val = self.rlglFeatures.featureValues[featureName]
+      self.testUtils.checkResult(featureName, val)

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -7,6 +7,7 @@ from radiomics import firstorder, shape
 from testUtils import RadiomicsTestUtils
 import sys, os
 import logging
+from nose_parameterized import parameterized
 
 def setup_module(module):
     # run before anything in this file
@@ -49,66 +50,17 @@ class TestShape:
         # run after any methods in this class
         print ("") # this is to get a newline after the dots
 
-    def test_volume_BreastMRI(self):
-        testString = 'Volume'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    def generate_scenarios():
+      # get the feature names
+      featureNames = shape.RadiomicsShape.getFeatureNames()
+      logging.info('generate_scenarios: featureNames = %s', featureNames)
+      for f in featureNames:
+        yield (f)
 
-    def test_surfaceArea_BreastMRI(self):
-        testString = 'SurfaceArea'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_surfaceVolumeRatio_BreastMRI(self):
-        testString = 'SurfaceVolumeRatio'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_compactness1_BreastMRI(self):
-        testString = 'Compactness1'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_compactness2_BreastMRI(self):
-        testString = 'Compactness2'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_maximum3DDiameter_BreastMRI(self):
-        testString = 'Maximum3DDiameter'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_sphericalDisproportion_BreastMRI(self):
-        testString = 'SphericalDisproportion'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
-
-    def test_sphericity_BreastMRI(self):
-        testString = 'Sphericity'
-        logging.info('Test %s', testString)
-        self.shapeFeatures.enableFeatureByName(testString)
-        self.shapeFeatures.calculateFeatures()
-        val = self.shapeFeatures.featureValues[testString]
-        self.testUtils.checkResult(testString, val)
+    @parameterized.expand(generate_scenarios())
+    def test_scenario_BreastMRI(self, featureName):
+      logging.info('test_scenario: featureName = %s', featureName)
+      self.shapeFeatures.enableFeatureByName(featureName)
+      self.shapeFeatures.calculateFeatures()
+      val = self.shapeFeatures.featureValues[featureName]
+      self.testUtils.checkResult(featureName, val)


### PR DESCRIPTION
Simplify the feature tests by parameterizing the feature names for tests
rather than writing explicity tests for each, using the nose_parameterized
plugin.

The docstrings test now creates a separate test for each feature, rather than
one per feature class, allowing finer grained reporting on missing documentation.
Each of the tests now reports a warning about missing image and mask files though.

Updated circle.yml to install nose_parameterized for automated testing

Issue #7
