### PR TITLE
ENH: Log an error if the test check failed.

### DIFF
--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -272,9 +272,9 @@ class RadiomicsTestUtils:
     else:
       percentDiff = abs(1.0 - (value / baseline))
 
-    self.logger.debug('checkResult: %s, baseline value = %f, calculated = %f, diff = %f%%', key, float(baseline), value, percentDiff * 100)
-
     # check for a less than one percent difference
+    if (percentDiff >= 0.01):
+      self.logger.error('checkResult %s, baseline value = %f, calculated = %f, diff = %f%%', key, float(baseline), value, percentDiff * 100)
     assert(percentDiff < 0.01)
 
 # testUtils = RadiomicsTestUtils('glcm')


### PR DESCRIPTION
When running the tests on the CircleCI dashboard, it's
not showing the calculated feature value or differences
since the logging level is set to have minimal default
print outs. This change makes sure to log the error message,
but it won't print out anything if the check succeeds.
