### PR TITLE
ENH: Add LoG to testing

### DIFF
--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -1,5 +1,6 @@
 import SimpleITK as sitk
 import numpy, operator
+import logging
 
 def binImage(binwidth, parameterValues, parameterMatrix, parameterMatrixCoordinates):
   lowBound = min(parameterValues) - binwidth
@@ -75,11 +76,21 @@ def interpolateImage(imageNode, resampledPixelSpacing, interpolator=sitk.sitkBSp
   resampledImageNode = rif.Execute(imageNode)
   return resampledImageNode
 
+#
+# Use the SimpleITK LaplacianRecursiveGaussianImageFilter
+# on the input image with the given sigmaValue and return
+# the filtered image.
+# If sigmaValue is not greater than zero, return the input image.
+#
 def applyLoG(inputImage, sigmaValue=0.5):
-  lrgif = sitk.LaplacianRecursiveGaussianImageFilter()
-  lrgif.SetNormalizeAcrossScale(True)
-  lrgif.SetSigma(sigmaValue)
-  return lrgif.Execute(inputImage)
+  if sigmaValue > 0.0:
+    lrgif = sitk.LaplacianRecursiveGaussianImageFilter()
+    lrgif.SetNormalizeAcrossScale(True)
+    lrgif.SetSigma(sigmaValue)
+    return lrgif.Execute(inputImage)
+  else:
+    logging.info('applyLoG: sigma must be greater than 0.0: %g', sigmaValue)
+    return inputImage
 
 def applyThreshold(inputImage, lowerThreshold, upperThreshold, insideValue=None, outsideValue=0):
   # this mode is useful to generate the mask of thresholded voxels

--- a/tests/test_firstorder.py
+++ b/tests/test_firstorder.py
@@ -2,11 +2,12 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_firstorder.py
 
-from radiomics import firstorder
+from radiomics import firstorder, imageoperations
 from testUtils import RadiomicsTestUtils
 import sys, os
 import logging
 from nose_parameterized import parameterized
+from itertools import product
 
 testUtils = RadiomicsTestUtils('firstorder')
 firstOrderFeatures = None
@@ -30,31 +31,43 @@ class TestFirstOrder:
       # get the list of test cases for which we have baseline information
       testCases = testUtils.getTestCases()
       logging.info('generate_scenarios: testCases = %s', testCases)
+
+      # get the list of LoG sigma values for which we have baseline information
+      sigmas = [0.0] + testUtils.getLaplacianSigmas()
+      logging.info('generate_scenarios: sigmas = %s', sigmas)
+
       # get the list of features we'll be testing so we can generate the
-      # tuples of testcase:feature to iterate over
+      # tuples of testcase:sigma:feature to iterate over
       featureNames = firstorder.RadiomicsFirstOrder.getFeatureNames()
       logging.info('generate_scenarios: featureNames = %s', featureNames)
       test_tuples = []
-      for t in range(len(testCases)):
-        for f in range(len(featureNames)):
-          test_tuples.append((testCases[t], featureNames[f]))
+      for test_tuple in product(testCases, sigmas, featureNames):
+        test_tuples.append(test_tuple)
       logging.info('generate_scenarios: test_tuples = %s', test_tuples)
 
-      for p in range(len(test_tuples)):
-        yield (test_tuples[p][0], test_tuples[p][1])
+      for test_tuple in test_tuples:
+        yield test_tuple
 
     global testUtils
     @parameterized.expand(generate_scenarios(), testcase_func_name=testUtils.custom_name_func)
-    def test_scenario(self, testCase, featureName):
+    def test_scenario(self, testCase, sigma, featureName):
       print("")
       global testUtils
-      logging.info('test_scenario: testCase = %s, featureName = %s', testCase, featureName)
-      # set the test case and only recalculate features if changed
+      logging.info('test_scenario: testCase = %s, sigma = %f, featureName = %s', testCase, sigma, featureName)
+      # set the test case and only recalculate features if there are changes
       testCaseChanged = testUtils.setTestCase(testCase)
+      testImage = testUtils.getImage()
+      # if it's a new test case or the sigma changed, rerun LoG
+      sigmaChanged = testUtils.setSigma(sigma)
+      if testCaseChanged or sigmaChanged:
+        logging.info('test_scenario: recalculating LoG with sigma %f', sigma)
+        # relies on applyLoG returning the image unchanged if sigma is 0.0
+        logImage = imageoperations.applyLoG(testImage, sigma)
+        testImage = logImage
       global firstOrderFeatures
-      if firstOrderFeatures == None or testCaseChanged:
-        logging.info("Instantiating FirstOrder for testCase %s.", testCase)
-        firstOrderFeatures = firstorder.RadiomicsFirstOrder(testUtils.getImage(), testUtils.getMask())
+      if firstOrderFeatures == None or testCaseChanged or sigmaChanged:
+        logging.info("Instantiating FirstOrder for testCase %s/", testCase)
+        firstOrderFeatures = firstorder.RadiomicsFirstOrder(testImage, testUtils.getMask())
 
       firstOrderFeatures.disableAllFeatures()
       firstOrderFeatures.enableFeatureByName(featureName)

--- a/tests/test_glcm.py
+++ b/tests/test_glcm.py
@@ -2,11 +2,12 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_glcm.py
 
-from radiomics import glcm
+from radiomics import imageoperations, glcm
 from testUtils import RadiomicsTestUtils
 import sys, os
 import logging
 from nose_parameterized import parameterized
+from itertools import product
 
 testUtils = RadiomicsTestUtils('glcm')
 glcmFeatures = None
@@ -30,31 +31,43 @@ class TestGLCM:
       # get the list of test cases for which we have baseline information
       testCases = testUtils.getTestCases()
       logging.info('generate_scenarios: testCases = %s', testCases)
+
+      # get the list of LoG sigma values for which we have baseline information
+      sigmas = [0.0] + testUtils.getLaplacianSigmas()
+      logging.info('generate_scenarios: sigmas = %s', sigmas)
+
       # get the list of features we'll be testing so we can generate the
-      # tuples of testcase:feature to iterate over
+      # tuples of testcase:sigma:feature to iterate over
       featureNames = glcm.RadiomicsGLCM.getFeatureNames()
       logging.info('generate_scenarios: featureNames = %s', featureNames)
       test_tuples = []
-      for t in range(len(testCases)):
-        for f in range(len(featureNames)):
-          test_tuples.append((testCases[t], featureNames[f]))
+      for test_tuple in product(testCases, sigmas, featureNames):
+        test_tuples.append(test_tuple)
       logging.info('generate_scenarios: test_tuples = %s', test_tuples)
 
-      for p in range(len(test_tuples)):
-        yield (test_tuples[p][0], test_tuples[p][1])
+      for test_tuple in test_tuples:
+        yield test_tuple
 
     global testUtils
     @parameterized.expand(generate_scenarios(), testcase_func_name=testUtils.custom_name_func)
-    def test_scenario(self, testCase, featureName):
+    def test_scenario(self, testCase, sigma, featureName):
       print("")
       global testUtils
-      logging.info('test_scenario: testCase = %s, featureName = %s', testCase, featureName)
-      # set the test case and only recalculate features if changed
+      logging.info('test_scenario: testCase = %s, sigma = %s, featureName = %s', testCase, sigma, featureName)
+      # set the test case and only recalculate features if there are changes
       testCaseChanged = testUtils.setTestCase(testCase)
+      testImage = testUtils.getImage()
+      # if it's a new test case or the sigma changed, rerun LoG
+      sigmaChanged = testUtils.setSigma(sigma)
+      if testCaseChanged or sigmaChanged:
+        logging.info('test_scenario: recalculating LoG with sigma %f', sigma)
+        # relies on applyLoG returning the image unchanged if sigma is 0.0
+        logImage = imageoperations.applyLoG(testImage, sigma)
+        testImage = logImage
       global glcmFeatures
-      if glcmFeatures == None or testCaseChanged:
+      if glcmFeatures == None or testCaseChanged or sigmaChanged:
         logging.info("Instantiating GLCM for testCase %s.", testCase)
-        glcmFeatures = glcm.RadiomicsGLCM(testUtils.getImage(), testUtils.getMask())
+        glcmFeatures = glcm.RadiomicsGLCM(testImage, testUtils.getMask())
 
       glcmFeatures.disableAllFeatures()
       glcmFeatures.enableFeatureByName(featureName)

--- a/tests/test_glszm.py
+++ b/tests/test_glszm.py
@@ -2,11 +2,12 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_glszm.py
 
-from radiomics import glszm
+from radiomics import imageoperations, glszm
 from testUtils import RadiomicsTestUtils
 import sys, os
 import logging
 from nose_parameterized import parameterized
+from itertools import product
 
 testUtils = RadiomicsTestUtils('glszm')
 glszmFeatures = None
@@ -30,31 +31,44 @@ class TestGLSZM:
       # get the list of test cases for which we have baseline information
       testCases = testUtils.getTestCases()
       logging.info('generate_scenarios: testCases = %s', testCases)
+
+      # get the list of LoG sigma values for which we have baseline information
+      sigmas = [0.0] + testUtils.getLaplacianSigmas()
+      logging.info('generate_scenarios: sigmas = %s', sigmas)
+
       # get the list of features we'll be testing so we can generate the
-      # tuples of testcase:feature to iterate over
+      # tuples of testcase:sigma:feature to iterate over
       featureNames = glszm.RadiomicsGLSZM.getFeatureNames()
       logging.info('generate_scenarios: featureNames = %s', featureNames)
       test_tuples = []
-      for t in range(len(testCases)):
-        for f in range(len(featureNames)):
-          test_tuples.append((testCases[t], featureNames[f]))
+      for test_tuple in product(testCases, sigmas, featureNames):
+        test_tuples.append(test_tuple)
       logging.info('generate_scenarios: test_tuples = %s', test_tuples)
 
-      for p in range(len(test_tuples)):
-        yield (test_tuples[p][0], test_tuples[p][1])
+      for test_tuple in test_tuples:
+        yield test_tuple
 
     global testUtils
     @parameterized.expand(generate_scenarios(), testcase_func_name=testUtils.custom_name_func)
-    def test_scenario(self, testCase, featureName):
+    def test_scenario(self, testCase, sigma, featureName):
       print("")
       global testUtils
-      logging.info('test_scenario: testCase = %s, featureName = %s', testCase, featureName)
-      # set the test case and only recalculate features if changed
+      logging.info('test_scenario: testCase = %s, sigma = %f, featureName = %s', testCase, sigma, featureName)
+      # set the test case and only recalculate features if there are changes
       testCaseChanged = testUtils.setTestCase(testCase)
+
+      testImage = testUtils.getImage()
+      # if it's a new test case or the sigma changed, rerun LoG
+      sigmaChanged = testUtils.setSigma(sigma)
+      if testCaseChanged or sigmaChanged:
+        logging.info('test_scenario: recalculating LoG with sigma %f', sigma)
+        # relies on applyLoG returning the image unchanged if sigma is 0.0
+        logImage = imageoperations.applyLoG(testImage, sigma)
+        testImage = logImage
       global glszmFeatures
-      if glszmFeatures == None or testCaseChanged:
+      if glszmFeatures == None or testCaseChanged or sigmaChanged:
         logging.info("Instantiating GLSZM for testCase %s.", testCase)
-        glszmFeatures = glszm.RadiomicsGLSZM(testUtils.getImage(), testUtils.getMask())
+        glszmFeatures = glszm.RadiomicsGLSZM(testImage, testUtils.getMask())
 
       glszmFeatures.disableAllFeatures()
       glszmFeatures.enableFeatureByName(featureName)

--- a/tests/test_rlgl.py
+++ b/tests/test_rlgl.py
@@ -2,11 +2,12 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_rlgl.py
 
-from radiomics import rlgl
+from radiomics import imageoperations, rlgl
 from testUtils import RadiomicsTestUtils
 import sys, os
 import logging
 from nose_parameterized import parameterized
+from itertools import product
 
 testUtils = RadiomicsTestUtils('rlgl')
 rlglFeatures = None
@@ -30,31 +31,43 @@ class TestRLGL:
       # get the list of test cases for which we have baseline information
       testCases = testUtils.getTestCases()
       logging.info('generate_scenarios: testCases = %s', testCases)
+
+      # get the list of LoG sigma values for which we have baseline information
+      sigmas = [0.0] + testUtils.getLaplacianSigmas()
+      logging.info('generate_scenarios: sigmas = %s', sigmas)
+
       # get the list of features we'll be testing so we can generate the
       # tuples of testcase:feature to iterate over
       featureNames = rlgl.RadiomicsRLGL.getFeatureNames()
       logging.info('generate_scenarios: featureNames = %s', featureNames)
       test_tuples = []
-      for t in range(len(testCases)):
-        for f in range(len(featureNames)):
-          test_tuples.append((testCases[t], featureNames[f]))
+      for test_tuple in product(testCases, sigmas, featureNames):
+        test_tuples.append(test_tuple)
       logging.info('generate_scenarios: test_tuples = %s', test_tuples)
 
-      for p in range(len(test_tuples)):
-        yield (test_tuples[p][0], test_tuples[p][1])
+      for test_tuple in test_tuples:
+        yield test_tuple
 
     global testUtils
     @parameterized.expand(generate_scenarios(), testcase_func_name=testUtils.custom_name_func)
-    def test_scenario(self, testCase, featureName):
+    def test_scenario(self, testCase, sigma, featureName):
       print("")
       global testUtils
-      logging.info('test_scenario: testCase = %s, featureName = %s', testCase, featureName)
-      # set the test case and only recalculate features if changed
+      logging.info('test_scenario: testCase = %s, sigma = %s, featureName = %s', testCase, sigma, featureName)
+      # set the test case and only recalculate features if there are changes
       testCaseChanged = testUtils.setTestCase(testCase)
+      testImage = testUtils.getImage()
+      # if it's a new test case or the sigma changed, rerun LoG
+      sigmaChanged = testUtils.setSigma(sigma)
+      if testCaseChanged or sigmaChanged:
+        logging.info('test_scenario: recalculating LoG with sigma %f', sigma)
+        # relies on applyLoG returning the image unchanged if sigma is 0.0
+        logImage = imageoperations.applyLoG(testImage, sigma)
+        testImage = logImage
       global rlglFeatures
       if rlglFeatures == None or testCaseChanged:
         logging.info("Instantiating RLGL for testCase %s.", testCase)
-        rlglFeatures = rlgl.RadiomicsRLGL(testUtils.getImage(), testUtils.getMask())
+        rlglFeatures = rlgl.RadiomicsRLGL(testImage, testUtils.getMask())
 
       rlglFeatures.disableAllFeatures()
       rlglFeatures.enableFeatureByName(featureName)

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -2,11 +2,12 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_shape.py
 
-from radiomics import shape
+from radiomics import imageoperations, shape
 from testUtils import RadiomicsTestUtils
 import sys, os
 import logging
 from nose_parameterized import parameterized
+from itertools import product
 
 testUtils = RadiomicsTestUtils('shape')
 shapeFeatures = None
@@ -30,31 +31,43 @@ class TestShape:
       # get the list of test cases for which we have baseline information
       testCases = testUtils.getTestCases()
       logging.info('generate_scenarios: testCases = %s', testCases)
+
+      # get the list of LoG sigma values for which we have baseline information
+      sigmas = [0.0] + testUtils.getLaplacianSigmas()
+      logging.info('generate_scenarios: sigmas = %s', sigmas)
+
       # get the list of features we'll be testing so we can generate the
-      # tuples of testcase:feature to iterate over
+      # tuples of testcase:sigma:feature to iterate over
       featureNames = shape.RadiomicsShape.getFeatureNames()
       logging.info('generate_scenarios: featureNames = %s', featureNames)
       test_tuples = []
-      for t in range(len(testCases)):
-        for f in range(len(featureNames)):
-          test_tuples.append((testCases[t], featureNames[f]))
+      for test_tuple in product(testCases, sigmas, featureNames):
+        test_tuples.append(test_tuple)
       logging.info('generate_scenarios: test_tuples = %s', test_tuples)
 
-      for p in range(len(test_tuples)):
-        yield (test_tuples[p][0], test_tuples[p][1])
+      for test_tuple in test_tuples:
+        yield test_tuple
 
     global testUtils
     @parameterized.expand(generate_scenarios(), testcase_func_name=testUtils.custom_name_func)
-    def test_scenario(self, testCase, featureName):
+    def test_scenario(self, testCase, sigma, featureName):
       print("")
       global testUtils
-      logging.info('test_scenario: testCase = %s, featureName = %s', testCase, featureName)
-      # set the test case and only recalculate features if changed
+      logging.info('test_scenario: testCase = %s, sigma = %f, featureName = %s', testCase, sigma, featureName)
+      # set the test case and only recalculate features if there are changes
       testCaseChanged = testUtils.setTestCase(testCase)
+      testImage = testUtils.getImage()
+      # if it's a new test case or the sigma changed, rerun LoG
+      sigmaChanged = testUtils.setSigma(sigma)
+      if testCaseChanged or sigmaChanged:
+        logging.info('test_scenario: recalculating LoG with sigma %f', sigma)
+        # relies on applyLoG returning the image unchanged if sigma is 0.0
+        logImage = imageoperations.applyLoG(testImage, sigma)
+        testImage = logImage
       global shapeFeatures
-      if shapeFeatures == None or testCaseChanged:
+      if shapeFeatures == None or testCaseChanged or sigmaChanged:
         logging.info("Instantiating Shape for testCase %s.", testCase)
-        shapeFeatures = shape.RadiomicsShape(testUtils.getImage(), testUtils.getMask())
+        shapeFeatures = shape.RadiomicsShape(testImage, testUtils.getMask())
 
       shapeFeatures.disableAllFeatures()
       shapeFeatures.enableFeatureByName(featureName)


### PR DESCRIPTION
The LoG operation is a preprocessing step to be performed outside the feature classes, so it has to be done in the testing suite while iterating over the range of sigma values.
Updated the testing utilities methods to use a default of 0.0 to signal not applying the LoG.
Only test the 3D LoG results as that's what sitk calculates.

Add the saving, setting, testing of the sigma values to the test suite. For now, it's hard coded to 0.5 to 5.0 in steps of 0.5. In the baseline file, the sigma values are incorporated into the column headers with an underscore instead of a decimal, so added utility methods to convert from floats to strings. In the method to get the baseline feature, construct a different feature name if sigma is set. Iterate over the sigmas for each test case as well as features, so the testing scenarios have three variables.

After discussion with Vivek, he felt that the 1% difference between
baseline Matlab and computed pyradiomics feature values was too strict
and was resulting in too many false failures. With the check set to 1%,
testing the firstorder features and running 825 tests, the result was:
FAILED (errors=54, failures=756)
Setting it to 3%, the result was:
FAILED (errors=54, failures=744)

Added a graceful failure to the image operations applyLoG so that passing
an invalid sigma results in the return of the unprocessing input image.
Print out an information string rather than causing an exception.

Updated test output to log more clearly when feature names are not found in the baseline.

Issue #35
