### PR TITLE
BUG: Expand documentation and test

### DIFF
--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -314,7 +314,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     """
     Using coefficients i, j, calculate and return the mean Homogeneity 1 for all 13 GLCMs.
 
-    Homogeneity 1 is a measure of the similarity in intensity values for neighboring voxels.
+    Homogeneity 1 is a measure of the similarity in intensity values for
+    neighboring voxels. It is a measure of local homogeneity that increases
+    with less contrast in the window.
     """
     i = self.coefficients['i']
     j = self.coefficients['j']
@@ -334,7 +336,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     return (homo2.mean())
 
   def getImc1FeatureValue(self):
-    """Using coefficients HX, HY, HXY, HXY1, HXY2, calculate and return the mean IMC1 for all 13 GLCMs."""
+    """
+    Using coefficients HX, HY, HXY, HXY1, HXY2, calculate and return the mean
+    Informal Measure of Correlation 1 for all 13 GLCMs.
+    """
     HX = self.coefficients['HX']
     HY = self.coefficients['HY']
     HXY = self.coefficients['HXY']
@@ -345,7 +350,8 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
 
   def getImc2FeatureValue(self):
     """
-    Using coefficients HXY, HXY2, calculate and return the mean IMC2 for all 13 GLCMs.
+    Using coefficients HXY, HXY2, calculate and return the mean Informal Measure
+    of Correlation 2 for all 13 GLCMs.
 
     NOT IMPLEMENTED
     """
@@ -370,11 +376,12 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     """
     Using coefficients i, j, Ng, calculate and return the mean IDMN for all 13 GLCMs.
 
-    IDMN is a measure of the local homogeneity of an image. IDMN weights
-    are the inverse of the Contrast weights (decreasing exponentially from
-    the diagonal i=j in the GLCM). Unlike Homogeneity2, IDMN normalizes the
-    square of the difference between neighboring intensity values by
-    dividing over the square of the total number of discrete intensity values.
+    IDMN (inverse difference moment normalized)  is a measure of the local
+    homogeneity of an image. IDMN weights are the inverse of the Contrast
+    weights (decreasing exponentially from the diagonal i=j in the GLCM).
+    Unlike Homogeneity2, IDMN normalizes the square of the difference between
+    neighboring intensity values by dividing over the square of the total
+    number of discrete intensity values.
     """
     i = self.coefficients['i']
     j = self.coefficients['j']
@@ -386,9 +393,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     """
     Using coefficients i, j, Ng, calculate and return the mean IDN for all 13 GLCMs.
 
-    IDN is another measure of the local homogeneity of an image. Unlike
-    Homogeneity1, IDN normalizes the difference between the neighboring
-    intensity values by dividing over the total number of discrete intensity values.
+    IDN (inverse difference normalized) is another measure of the local
+    homogeneity of an image. Unlike Homogeneity1, IDN normalizes the difference
+    between the neighboring intensity values by dividing over the total number
+    of discrete intensity values.
     """
     i = self.coefficients['i']
     j = self.coefficients['j']

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -8,6 +8,10 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
   def __init__(self, inputImage, inputMask, **kwargs):
     super(RadiomicsGLSZM,self).__init__(inputImage, inputMask, **kwargs)
 
+    if inputImage == None or inputMask == None:
+      print('ERROR GLSZM: missing input image or mask')
+      return
+
     self.imageArray = sitk.GetArrayFromImage(inputImage)
     self.maskArray = sitk.GetArrayFromImage(inputMask)
 

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -75,7 +75,11 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     """
     Calculate the compactness (1) of the tumor region.
 
-    Compactness 1 is a measure of how compact the shape of the tumor is relative to a sphere (most compact).
+    Compactness 1 is a measure of how compact the shape of the tumor is
+    relative to a sphere (most compact). It is a dimensionless measure,
+    independent of scale and orientation. Compactness 1 is defined as the
+    ratio of volume to the (surface area)^(1.5). This is a measure of the
+    compactness of the shape of the image ROI
     """
     return ( (self.Volume) / ((self.SurfaceArea)**(2.0/3.0) * numpy.sqrt(numpy.pi)) )
 
@@ -83,7 +87,10 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     """
     Calculate the Compactness (2) of the tumor region.
 
-    Compactness 2 is a measure of how compact the shape of the tumor is relative to a sphere (most compact).
+    Compactness 2 is a measure of how compact the shape of the tumor is
+    relative to a sphere (most compact). It is a dimensionless measure,
+    independent of scale and orientation. This is a measure of the compactness
+    of the shape of the image ROI.
     """
     return ((36.0 * numpy.pi) * ((self.Volume)**2.0)/((self.SurfaceArea)**3.0))
 

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -2,7 +2,7 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_docstrings.py
 
-from radiomics import firstorder, glcm, rlgl, shape
+from radiomics import firstorder, glcm, rlgl, shape, glszm
 from testUtils import RadiomicsTestUtils
 import SimpleITK as sitk
 import sys, os
@@ -67,6 +67,14 @@ class TestDocStrings:
     def test_shape(self, featureName):
        logging.info('%s', featureName)
        features = shape.RadiomicsShape(None, None)
+       doc = eval('features.get'+featureName+'FeatureValue.__doc__')
+       logging.info('%s', doc)
+       assert(doc != None)
+
+    @parameterized.expand(generate_scenarios(glszm.RadiomicsGLSZM))
+    def test_shape(self, featureName):
+       logging.info('%s', featureName)
+       features = glszm.RadiomicsGLSZM(None, None)
        doc = eval('features.get'+featureName+'FeatureValue.__doc__')
        logging.info('%s', doc)
        assert(doc != None)


### PR DESCRIPTION
Add some missing documentation to the pyradiomics features from the
HeterogeneityCAD wiki. Expanded acronyms (IMC, IDMN, IDN) and added
documentation to differentiate between some features that are name1 and name2.
Adding missing docstrings test for GLSZM and added a null image/mask check
to the feature class.

Issue #3
