### PR TITLE
Add support for multilevel wavelet decompositions

### DIFF
--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -115,10 +115,17 @@ def swt3(inputImage, wavelet="coif1", level=1, start_level=0):
 
   original_shape = matrix.shape
   adjusted_shape = tuple([dim+1 if dim % 2 != 0 else dim for dim in original_shape])
-  data.resize(adjusted_shape)
+  data = numpy.resize(data, adjusted_shape)
 
   if not isinstance(wavelet, pywt.Wavelet):
     wavelet = pywt.Wavelet(wavelet)
+
+  for i in range(0, start_level):
+    H, L = decompose_i(data, wavelet)
+    LH, LL = decompose_j(L, wavelet)
+    LLH, LLL = decompose_k(LL, wavelet)
+
+    data = LLL.copy()
 
   ret = []
   for i in range(start_level, start_level + level):
@@ -143,14 +150,14 @@ def swt3(inputImage, wavelet="coif1", level=1, start_level=0):
            'LLH': LLH}
     for decName, decImage in dec.iteritems():
       decTemp = decImage.copy()
-      decTemp.resize(original_shape)
+      decTemp= numpy.resize(decTemp, original_shape)
       sitkImage = sitk.GetImageFromArray(decTemp)
       sitkImage.CopyInformation(inputImage)
       dec[decName] = sitkImage
 
     ret.append(dec)
 
-  data.resize(original_shape)
+  data= numpy.resize(data, original_shape)
   approximation = sitk.GetImageFromArray(data)
   approximation.CopyInformation(inputImage)
 


### PR DESCRIPTION
WIP, the changes to the calculation in this pull request are finished, but testing currently skips wavelet testing.

This pull request enables multi-level wavelet decompositions. 
Additionally, adds conversion of `approximation` to sitkImage, which is needed to use `approximation` as input for feature calculation classes. `approximation` is the LLL decomposition of the last iteration, which is not passed back in `ret`

See also PR #59 
CC @Radiomics/developers 
