### PR TITLE
Add verbose option and progressbar

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ dependencies:
     - pip install numpy
     - pip install --trusted-host www.simpleitk.org -f http://www.simpleitk.org/SimpleITK/resources/software.html SimpleITK
     - pip install nose-parameterized
+    - pip install tqdm
     - git clone https://github.com/nigma/pywt.git && cd pywt && python setup.py install
 test:
   override:

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -18,6 +18,7 @@ class RadiomicsFeaturesBase(object):
     self.interpolator = sitk.sitkBSpline
     self.padDistance = 5 # no padding
     self.padFillValue = 0
+    self.verbose = True
 
     for key,value in kwargs.iteritems():
       if key == 'binWidth':
@@ -30,7 +31,9 @@ class RadiomicsFeaturesBase(object):
         self.padDistance = value
       elif key == 'padFillValue':
         self.padFillValue = value
-      else:
+      elif key == 'verbose':
+        self.verbose = value
+      elif self.verbose:
         print 'Warning: unknown parameter:',key
 
     # all features are disabled by default

--- a/radiomics/firstorder.py
+++ b/radiomics/firstorder.py
@@ -9,7 +9,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     super(RadiomicsFirstOrder,self).__init__(inputImage,inputMask,**kwargs)
 
     if inputImage == None or inputMask == None:
-      print ('ERROR FirstOrder: missing input image or mask')
+      if self.verbose: print ('ERROR FirstOrder: missing input image or mask')
       return
 
     self.pixelSpacing = inputImage.GetSpacing()

--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -2,6 +2,7 @@ import numpy
 import collections
 from radiomics import base, imageoperations
 import SimpleITK as sitk
+from tqdm import  trange
 
 class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   """GLCM feature calculation."""
@@ -9,7 +10,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     super(RadiomicsGLCM,self).__init__(inputImage, inputMask, **kwargs)
 
     if inputImage == None or inputMask == None:
-      print('ERROR GLCM: missing input image or mask')
+      if self.verbose: print('ERROR GLCM: missing input image or mask')
       return
 
     self.imageArray = sitk.GetArrayFromImage(inputImage)
@@ -41,14 +42,11 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     maxheight = self.matrix.shape[0]
     indices = zip(*self.matrixCoordinates)
 
-    numIndices = len(indices)
-    index = 0
+    if self.verbose: bar = trange(len(indices), desc= 'calculate GLCM')
 
     for h, c, r in indices:
-      if index % 100 == 0:
-        percentProgress = (float(index) / float(numIndices)) * 100.0
-        print ('calculate GLCM: %.2f%s' % (percentProgress, '%'))
-      index = index + 1
+      if self.verbose: bar.update()
+
       for angles_idx, angle in enumerate(angles):
         for distances_idx, distance in enumerate(distances):
           i = self.matrix[h, c, r]
@@ -63,6 +61,8 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
               j = self.matrix[height, col, row]
               j_idx = int(j-1)
               self.P_glcm[i_idx, j_idx, distances_idx, angles_idx] += 1
+
+    if self.verbose: bar.close()
 
   def createGLCM(self):
     """

--- a/radiomics/rlgl.py
+++ b/radiomics/rlgl.py
@@ -9,7 +9,7 @@ class RadiomicsRLGL(base.RadiomicsFeaturesBase):
       super(RadiomicsRLGL,self).__init__(inputImage, inputMask, **kwargs)
 
       if inputImage == None or inputMask == None:
-        print('ERROR RLGL: missing input image or mask')
+        if self.verbose: print('ERROR RLGL: missing input image or mask')
         return
 
       self.imageArray = sitk.GetArrayFromImage(inputImage)

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -10,7 +10,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     super(RadiomicsShape,self).__init__(inputImage,inputMask, **kwargs)
 
     if inputImage == None or inputMask == None:
-      print('ERROR Shape: missing input image or mask')
+      if self.verbose: print('ERROR Shape: missing input image or mask')
       return
 
     self.pixelSpacing = inputImage.GetSpacing()


### PR DESCRIPTION
This pull request adds a verbose option to enable suppression of all prints during execution of the code.
Additionally, the regular progress prints provided by `glcm` and `glszm` are replaced by a progressbar, which is part of package `tqdm` (this package is also added to circle.yml)

Lastly, multiple calls to `numpy.sum` in `rlgl` and `glszm` are simplified by using one call, and specifying the multiple axes as a tuple of ints.

See also #59 
CC @Radiomics/developers 
