### PR TITLE
Glszm matrix calculation

### DIFF
--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -67,15 +67,34 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       ind = zip(*numpy.where(self.matrix==i))
       ind = list(set(ind).intersection(set(zip(*self.matrixCoordinates))))
 
-      while ind: # check if ind is not empty
-        # First coordinate
-        ind_node = ind[0]
+      while ind: # check if ind is not empty: unprocessed regions for current gray level
+        # Pop first coordinate of an unprocessed zone, start new stack
+        ind_region = [ind.pop()]
 
-        # Remove first element to prevent reprocessing
-        ind = ind[1:]
+        # Define regionSize
+        regionSize = 0
 
-        # Size of the region (# of voxels in region)
-        regionSize, ind = self.growZone(ind_node, ind, angles)
+        # Grow zone for item popped from stack of region indices, loop until stack of region indices is exhausted
+        # Each loop represents one voxel belonging to current zone. Therefore, count number of loops as regionSize
+        while ind_region:
+          regionSize+=1
+
+          # Use pop to remove next node for set of unprocessed region indices
+          ind_node = ind_region.pop()
+
+          # get all coordinates in the 26-connected region, 2 voxels per angle
+          region_full = [tuple(sum(a) for a in zip(ind_node,angle_i)) for angle_i in angles]
+          region_full += [tuple(sum(a) for a in zip(ind_node,angle_i)) for angle_i in angles*-1]
+
+          # get all unprocessed coordinates in the 26-connected region with same gray level
+          region_level = list(set(ind).intersection(set(region_full)))
+
+          # Remove already processed indices to prevent reprocessing
+          ind = list(set(ind) - set(region_level))
+
+          # Add all found neighbours to the total stack of unprocessed neighbours
+          ind_region.extend(region_level)
+
 
         # Update the gray level size zone matrix
         P_glszm[i-1,regionSize-1] += 1
@@ -87,33 +106,6 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     P_glszm_bounds = numpy.argwhere(P_glszm)
     (xstart, ystart), (xstop, ystop) = P_glszm_bounds.min(0), P_glszm_bounds.max(0) + 1
     self.P_glszm = P_glszm[xstart:xstop,:ystop]
-
-  def growZone(self, ind_node, ind, angles):
-    """
-    Region growing. Recursive procedure, where each single call operates on a single voxel:
-     removes neighbouring voxels that are equal to itself from indices and calls growZone() on these
-
-    :returns # of voxels belonging to the same (sub)region, remaining indices to process
-    """
-
-    region_Size = 1
-
-    # get all coordinates in the 26-connected region, 2 voxels per angle
-    region_full = [tuple(sum(a) for a in zip(ind_node,angle_i)) for angle_i in angles]
-    region_full += [tuple(sum(a) for a in zip(ind_node,angle_i)) for angle_i in angles*-1]
-
-    # get all unprocessed coordinates in the 26-connected region with same gray level
-    region_level = list(set(ind).intersection(set(region_full)))
-
-    # Remove already processed indices
-    ind = list(set(ind) - set(region_level))
-
-    # for every found node, get number of unprocessed indices with same gray level
-    for new_node in region_level:
-      subRegion_size, ind = self.growZone(new_node, ind, angles)
-      region_Size += subRegion_size
-
-    return region_Size, ind
 
   def calculateCoefficients(self):
     sumP_glszm = numpy.sum(self.P_glszm, (0, 1) )


### PR DESCRIPTION
This pull request reviews the GLSZM feature class.

The only change is in the calculation of the matrix. In the pyradiomics code, only 13 voxels were assessed around each inputvoxel (one per angle), and the found voxels were not recursively assessed (e.g. assessed whether the neighbors of the neighbors also belonged to the same zone). This had the effect that one zone had a maximum size of 14.

For each gray level, a set, `ind`, is generated, which contains the indices to all voxels with the current gray level. All these have to be divided into a certain zone of size.
This pull request grows every separate zone by implementing a stack (`ind_region`); for each new zone, the stack is initialized containing an index which is popped from `ind`. 

Then, in a continuous loop, an index is popped from the stack, for which the indices of possible neighbors are calculated and an intersection is made between these calculated possibles and the total set of indices (containing only unprocessed indices). 
This provides the indices to the all neighbors of the input index with equal gray level. All these found indices are removed from `ind` and pushed onto the stack. This is repeated until the stack is exhausted (e.g. all voxels of the current zone have been assessed at some point). The number of iterations is counted (equal to zone size) and stored in the zone matrix.
As all processed indices are also removed from `ind`, any remaining indices belong to a different zone, so the above is looped until `ind` is also exhausted (e.g. all zones for current gray level have been quantified).

The formulas match those in RLGL, and produces the same errors due to the missing exponents in `ShortRunHighGrayLevelEmphasis` and `LongRunLowGrayLevelEmphasis`, known in `glszm.py` as `HighIntensitySmallAreaEmphasis` and `LowIntensityLargeAreaEmphasis`, respectively.

Still, a lot of differences are found between matlab and pyradiomics. If you take the previous paragraph into account, case 'breast1' is computing correctly, but other cases produce a lot of errors.
For this, I think the error lies in the calculation of the zone matrix in matlab.

If you look at the calculated values for `IntensityVariability`, you can see that for 'lung1', 'lung2' and 'brain2', these are 1. This means that the (sum of # of zones per each gray level) ^ 2 = (sum of # of zones for each gray level). This, in turn, means that all elements are either 0 or 1 (e.g. every gray level has either 0 or 1 zones). 

This is due to the following line in matlab: `ind = find(dataTemp==i);` (line 62 in `glszm3d_maastro.m`). This line is meant to find unprocessed indices, but in dataTemp, these are all set to 1, so for gray levels, other than 1, this will return nothing, and no extra zones are assessed, even though they may exist.
