### PR TITLE
Change Log to Log2 in `glcm` entropy calculations

### DIFF
--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -133,16 +133,16 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     pxSuby = numpy.array([ numpy.sum(self.P_glcm[numpy.abs(i-j) == k], 0) for k in kValuesDiff ])
 
     # entropy of px # shape = (distances.size, angles)
-    HX = (-1) * numpy.sum( (px * numpy.log(px+eps)), (0, 1))
+    HX = (-1) * numpy.sum( (px * numpy.log2(px+eps)), (0, 1))
     # entropy of py # shape = (distances.size, angles)
-    HY = (-1) * numpy.sum( (py * numpy.log(py+eps)), (0, 1))
+    HY = (-1) * numpy.sum( (py * numpy.log2(py+eps)), (0, 1))
     # shape = (distances.size, angles)
-    HXY = (-1) * numpy.sum( (self.P_glcm * numpy.log(self.P_glcm+eps)), (0, 1) )
+    HXY = (-1) * numpy.sum( (self.P_glcm * numpy.log2(self.P_glcm+eps)), (0, 1) )
 
     # shape = (distances.size, angles)
-    HXY1 = (-1) * numpy.sum( (self.P_glcm * numpy.log(px*py+eps)), (0, 1) )
+    HXY1 = (-1) * numpy.sum( (self.P_glcm * numpy.log2(px*py+eps)), (0, 1) )
     # shape = (distances.size, angles)
-    HXY2 = (-1) * numpy.sum( ((px*py) * numpy.log(px*py+eps)), (0, 1) )
+    HXY2 = (-1) * numpy.sum( ((px*py) * numpy.log2(px*py+eps)), (0, 1) )
 
     self.coefficients['Ng'] = Ng
     self.coefficients['eps'] = eps
@@ -258,7 +258,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     """
     pxSuby = self.coefficients['pxSuby']
     eps = self.coefficients['eps']
-    difent = (-1) * numpy.sum( (pxSuby*numpy.log(pxSuby+eps)), 0 )
+    difent = (-1) * numpy.sum( (pxSuby*numpy.log2(pxSuby+eps)), 0 )
     return (difent.mean())
 
   def getDissimilarityFeatureValue(self):
@@ -419,7 +419,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     """
     pxAddy = self.coefficients['pxAddy']
     eps = self.coefficients['eps']
-    sumentr = (-1) * numpy.sum( (pxAddy * numpy.log(pxAddy+eps)), 0 )
+    sumentr = (-1) * numpy.sum( (pxAddy * numpy.log2(pxAddy+eps)), 0 )
     return (sumentr.mean())
 
   def getSumVarianceFeatureValue(self):
@@ -432,7 +432,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     eps = self.coefficients['eps']
     pxAddy = self.coefficients['pxAddy']
     kValuesSum = self.coefficients['kValuesSum']
-    sumentr = (-1) * numpy.sum( (pxAddy * numpy.log(pxAddy+eps)), 0, keepdims= True )
+    sumentr = (-1) * numpy.sum( (pxAddy * numpy.log2(pxAddy+eps)), 0, keepdims= True )
     sumvar = numpy.sum( (pxAddy*((kValuesSum[:,None,None] - sumentr)**2)), 0 )
     return (sumvar.mean())
 


### PR DESCRIPTION
This pull request changes calculation of entropy in `glcm.py` form using logarithm of base e to logarithm of base 2.

In the Nature article, all entropies are calculated using the logarithm of base 2. In the code this is also the case for the calculation of entropy in `firstorder.py` (and for the calculation of firstorder entropy in matlab).
However, entropies in `glcm.py` are calculated using the natural logarithm (base e).

I separated this pull request from the other changes, as this change may increase the number of differences with the matlab code. Currently the matlab code also uses `log` instead of `log2` for entropy calculation in GLCM.
