### PR TITLE
ENH: only run feature tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,5 @@ dependencies:
     - git clone https://github.com/nigma/pywt.git && cd pywt && python setup.py install
 test:
   override:
-    - nosetests --with-xunit --logging-level=DEBUG --verbosity=3 tests
+    - nosetests --with-xunit --logging-level=DEBUG --verbosity=3 tests/test_features.py
     - cp nosetests.xml $CIRCLE_TEST_REPORTS


### PR DESCRIPTION
To simplify the output on CircleCI, only run the feature tests. This disables the
docstrings and matching tests so fewer total tests are run.
Note: currently only firstorder tests are enabled, so only 75 tests are expected
to be run on the CircleCI dashboard.
