### PR TITLE
Add NaN-value handling to testUtils

### DIFF
--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -407,7 +407,7 @@ class RadiomicsTestUtils:
 
     if math.isnan(value):
       self.diffs[self.getTestCase()][featureName] = numpy.nan
-
+      self.results[self.getTestCase()][featureName] = numpy.nan
     assert(not math.isnan(value))
 
     # save the result using the matlab class and feature names


### PR DESCRIPTION
When a feature produces a NaN-value, it does not add this feature to the dictionary of the testCase. If the situation occurs, where features produce NaN-values in some cases, but  not in others, then an error is thrown in `writeCSV` (missing key).
Use `dict.get()`, this allows specifying a default value, which is returned when key is not found (default value specified as "NaN")

Additionally, this Pull Request add `sorted` in two locations in the function `writeCSV`, sorting the output generated for testCase name and feature name.
