### PR TITLE
Compute shape features on labelMask

### DIFF
--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -39,7 +39,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
   def getVolumeFeatureValue(self):
     """Calculate the volume of the tumor region in cubic millimeters."""
-    return (self.matrix[self.matrixCoordinates].size * self.cubicMMPerVoxel)
+    return (self.targetVoxelArray.size.size * self.cubicMMPerVoxel)
 
   def getSurfaceAreaFeatureValue(self):
     """Calculate the surface area of the tumor region in square millimeters."""
@@ -59,9 +59,9 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     surfaceArea = 0
     for voxel in xrange(0, self.targetVoxelArray.size):
       i, j, k = self.matrixCoordinates[0][voxel], self.matrixCoordinates[1][voxel], self.matrixCoordinates[2][voxel]
-      fxy = (numpy.array([ self.matrix[i+1,j,k], self.matrix[i-1,j,k] ]) == 0) # evaluate to 1 if true, 0 if false
-      fyz = (numpy.array([ self.matrix[i,j+1,k], self.matrix[i,j-1,k] ]) == 0) # evaluate to 1 if true, 0 if false
-      fxz = (numpy.array([ self.matrix[i,j,k+1], self.matrix[i,j,k-1] ]) == 0) # evaluate to 1 if true, 0 if false
+      fxy = (numpy.array([ self.maskArray[i+1,j,k], self.maskArray[i-1,j,k] ]) == 0) # evaluate to 1 if true, 0 if false
+      fyz = (numpy.array([ self.maskArray[i,j+1,k], self.maskArray[i,j-1,k] ]) == 0) # evaluate to 1 if true, 0 if false
+      fxz = (numpy.array([ self.maskArray[i,j,k+1], self.maskArray[i,j,k-1] ]) == 0) # evaluate to 1 if true, 0 if false
       surface = (numpy.sum(fxz) * xz) + (numpy.sum(fyz) * yz) + (numpy.sum(fxy) * xy)
       surfaceArea += surface
 


### PR DESCRIPTION
This PR removes the need to set the voxels outside the delineation to a padding value during preprocessing.

For the calculation of shape features the value of gray levels are unimportant, and the shape of the delineation is also captured in the labelmap.
By using the labelmap instead of the original image, it is not necessary to set voxels outside the delineation to a padding value, as these are by definition already 0 in the labelmap (not segmented).

Furthermore, only in shape calculation are voxels outside delineation excluded based upon their intensity value, in other feature classes these voxels are excluded based upon whether or not their indices are a part of `self.matrixCoordinates` (which is based upon the labelmap).
Therefore, by this change, there is no need to set the voxels outside the delineation to a paddingvalue during preprocessing.

 N.B. voxels still need to be set to a paddingvalue in `rlrl.py`, but this is already handled separatly by the code in `rlgl.py`, and is based upon labelmap.
