### PR TITLE
Fix small bug in resampleImage

### DIFF
--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -121,7 +121,7 @@ def resampleImage(imageNode, maskNode, resampledPixelSpacing, interpolator=sitk.
   bbNewUBound = numpy.ceil( (bb[1::2] + 0.5) * spacingRatio)
 
   # Calculate the new size. Cast to int32 to prevent error in sitk.
-  newSize = numpy.array(bbNewUBound - bbNewLBound+1, dtype= 'int32')
+  newSize = numpy.array(bbNewUBound - bbNewLBound+1, dtype= 'int')
 
   # Determine continuous index of bbNewLBound in terms of the original Index coordinate space
   bbOriginalLBound = bbNewLBound / spacingRatio


### PR DESCRIPTION
Force newSize to "int" instead of "int32". In some cases, passing the newSize as "int32" caused SimpleITK to throw a datatype error.
