### PR TITLE
Handle calculation of `shape` separately

### DIFF
--- a/radiomics/signatures.py
+++ b/radiomics/signatures.py
@@ -72,6 +72,22 @@ class RadiomicsSignature():
 
         image, mask = self.loadImage(imageFilepath, maskFilepath)
 
+        # If shape should be calculation, handle it separately here
+        if 'shape' in self.enabledFeatures.keys():
+            enabledFeatures = self.enabledFeatures['shape']
+            shapeClass = self.featureClasses['shape'](image, mask, **self.kwargs)
+            if len(enabledFeatures) == 0:
+                shapeClass.enableAllFeatures()
+            else:
+                for feature in enabledFeatures:
+                    shapeClass.enableFeatureByName(feature)
+
+            if self.verbose: print "\t\tComputing shape"
+            shapeClass.calculateFeatures()
+            for (featureName, featureValue) in shapeClass.featureValues.iteritems():
+                newFeatureName = "original_shape_%s" %(featureName)
+                featureVector[newFeatureName] = featureValue
+
         # Make generators for all enabled input image types
         imageGenerators = []
         for imageType, customKwargs in self.inputImages.iteritems():
@@ -113,6 +129,10 @@ class RadiomicsSignature():
 
         featureVector = collections.OrderedDict()
         for featureClassName, enabledFeatures in self.enabledFeatures.iteritems():
+            # Handle calculation of shape features separately
+            if featureClassName == 'shape':
+                continue
+
             if featureClassName in self.getFeatureClassNames():
                 featureClass = self.featureClasses[featureClassName](image, mask, **kwargs)
 


### PR DESCRIPTION
Shape features are independent on the value of the grey level, and as such, different filters will not change the calculated values.
Therefore, handle shape calculation separately. If it should be calculated, calculate it once (on original image) and skip it in `calculateFeatures`, which is called for feature calculation on every inputImage (original and filtered).
