### PR TITLE
Add error handling to feature calculation

### DIFF
--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -64,4 +64,7 @@ class RadiomicsFeaturesBase(object):
   def calculateFeatures(self):
     for feature in self.enabledFeatures.keys():
       call = 'self.get'+feature+'FeatureValue()'
-      self.featureValues[feature] = eval(call)
+      try:
+        self.featureValues[feature] = eval(call)
+      except Exception:
+        self.featureValues[feature] = numpy.nan


### PR DESCRIPTION
When calculation of feature produces an error, return numpy.nan. This ensures that subsequent features are still calculated in case of an error.
