### PR TITLE
Parameterize label

### DIFF
--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -14,6 +14,7 @@ class RadiomicsFeaturesBase(object):
     """
 
     self.binWidth = kwargs.get('binWidth', 25)
+    self.label = kwargs.get('label', 1)
     self.verbose = kwargs.get('verbose', True)
 
     # all features are disabled by default
@@ -29,7 +30,7 @@ class RadiomicsFeaturesBase(object):
       return
 
     self.imageArray = sitk.GetArrayFromImage(self.inputImage)
-    self.maskArray = sitk.GetArrayFromImage(self.inputMask)
+    self.maskArray = (sitk.GetArrayFromImage(self.inputMask) == self.label).astype('int')
 
     self.matrix = self.imageArray.astype('int64')
     self.matrixCoordinates = numpy.where(self.maskArray != 0)

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -49,7 +49,7 @@ def generateAngles(size, maxDistance= 1):
 
   return angles
 
-def cropToTumorMask(imageNode, maskNode):
+def cropToTumorMask(imageNode, maskNode, label=1):
   """
   Create a sitkImage of the segmented region of the image based on the input label.
 
@@ -66,7 +66,7 @@ def cropToTumorMask(imageNode, maskNode):
   #Determine bounds
   lsif = sitk.LabelStatisticsImageFilter()
   lsif.Execute(imageNode, maskNode)
-  bb = lsif.GetBoundingBox(1)
+  bb = lsif.GetBoundingBox(label)
 
   ijkMinBounds = bb[0::2]
   ijkMaxBounds = size - bb[1::2] - 1
@@ -82,7 +82,7 @@ def cropToTumorMask(imageNode, maskNode):
 
   return croppedImageNode, croppedMaskNode
 
-def resampleImage(imageNode, maskNode, resampledPixelSpacing, interpolator=sitk.sitkBSpline, padDistance= 5):
+def resampleImage(imageNode, maskNode, resampledPixelSpacing, interpolator=sitk.sitkBSpline, label=1, padDistance=5):
   """Resamples image or label to the specified pixel spacing (The default interpolator is Bspline)
 
   'imageNode' is a SimpleITK Object, and 'resampledPixelSpacing' is the output pixel spacing.
@@ -106,7 +106,7 @@ def resampleImage(imageNode, maskNode, resampledPixelSpacing, interpolator=sitk.
   # Determine bounds of cropped volume in terms of original Index coordinate space
   lssif = sitk.LabelShapeStatisticsImageFilter()
   lssif.Execute(maskNode)
-  bb = numpy.array(lssif.GetBoundingBox(1))  # LBound and size of the bounding box, as (L_X, L_Y, L_Z, S_X, S_Y, S_Z)
+  bb = numpy.array(lssif.GetBoundingBox(label))  # LBound and size of the bounding box, as (L_X, L_Y, L_Z, S_X, S_Y, S_Z)
 
   # Do not resample in those directions where labelmap spans only one slice.
   oldSize = bb[3:]

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -27,8 +27,8 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
     self.inputMask = cpif.Execute(self.inputMask)
 
-    # Reassign self.maskArray using the now-padded self.inputMask
-    self.maskArray = sitk.GetArrayFromImage(self.inputMask)
+    # Reassign self.maskArray using the now-padded self.inputMask and make it binary
+    self.maskArray = (sitk.GetArrayFromImage(self.inputMask) == self.label).astype('int')
     self.matrixCoordinates = numpy.where(self.maskArray != 0)
 
     # Volume and Surface Area are pre-calculated


### PR DESCRIPTION
Allow user to set the value of the label in the mask image. This allows users to specify on which label the features should be calculated.
A standard label can be defined for a whole batch (`kwargs['label']`) or it can be passed to `featureextractor.execute`, in which case `kwargs` will be updated.
 By default, label = 1.
