### PR TITLE
BUG: Fix small bug in imageoperations

### DIFF
--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -314,7 +314,7 @@ def applyExponential(inputImage):
   return _scaleToOriginalRange(inputImage, im)
 
 def _scaleToOriginalRange(originalImage, filteredImage):
-  mmif = sitk.MinimumMaximumImageFilter
+  mmif = sitk.MinimumMaximumImageFilter()
   mmif.Execute(originalImage)
   im_max = mmif.GetMaximum()
   mmif.Execute(filteredImage)


### PR DESCRIPTION
`MinimumMaximumImageFilter` was not instantiated (missing parentheses)
