### PR TITLE
Fix rounding to 0 errors and flat region errors

### DIFF
--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -35,7 +35,7 @@ class RadiomicsFeaturesBase(object):
     self.imageArray = sitk.GetArrayFromImage(self.inputImage)
     self.maskArray = (sitk.GetArrayFromImage(self.inputMask) == self.label).astype('int')
 
-    self.matrix = self.imageArray.astype('int64')
+    self.matrix = self.imageArray.astype('float')
     self.matrixCoordinates = numpy.where(self.maskArray != 0)
 
     self.targetVoxelArray = self.matrix[self.matrixCoordinates]

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -12,7 +12,10 @@ def getHistogram(binwidth, parameterValues):
 
   binedges = numpy.arange(lowBound, highBound, binwidth)
 
-  binedges[-1] += 1 # ensures that max(self.targertVoxelArray) is binned to upper bin by numpy.digitize
+  binedges[-1] += 1  # ensures that max(self.targertVoxelArray) is binned to upper bin by numpy.digitize
+
+  if len(binedges) == 1:  # Flat region, ensure that there is 1 bin
+    binedges = 1
 
   return numpy.histogram(parameterValues, bins=binedges)
 


### PR DESCRIPTION
Rounding to 0 errors: use float datatype instead of int64 for `self.matrix`

Flat region errors: occurs in getHistogram. This occurs as only one edge is calculated, which causes all values to be digitized to '0' in `binImage`, where the code expects the values to start at 1 after binning.
Fix: If a flat region is present, ensure that image is 'binned' using 1 bin, which causes binImage to digitize to '1'.