### PR TITLE
Switch default value of 'verbose'  to False.

### DIFF
--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -17,7 +17,7 @@ class RadiomicsFeaturesBase(object):
     self.logger = logging.getLogger(self.__module__)
     self.binWidth = kwargs.get('binWidth', 25)
     self.label = kwargs.get('label', 1)
-    self.verbose = kwargs.get('verbose', True)
+    self.verbose = kwargs.get('verbose', False)
 
     # all features are disabled by default
     self.disableAllFeatures()

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -49,7 +49,7 @@ class RadiomicsFeaturesExtractor:
         # Try get values for interpolation and verbose. If not present in kwargs, use defaults
         self.resampledPixelSpacing = self.kwargs.get('resampledPixelSpacing', None)  # no resampling by default
         self.interpolator = self.kwargs.get('interpolator', sitk.sitkBSpline)
-        self.verbose = self.kwargs.get('verbose', True)
+        self.verbose = self.kwargs.get('verbose', False)
         self.padDistance = self.kwargs.get('padDistance', 5)
         self.label = self.kwargs.get('label', 1)
 


### PR DESCRIPTION
Only print out progress, etc. if user explicitly switches this on.