### PR TITLE
Fix use of maskArray in glcm, ngtdm

### DIFF
--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -125,7 +125,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     Ng = self.coefficients['Ng']
 
     # Exclude voxels outside segmentation, due to binning, no negative values will be encountered inside the mask
-    self.matrix[self.maskArray != self.label] = -1
+    self.matrix[self.maskArray == 0] = -1
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
     angles = imageoperations.generateAngles(size)

--- a/radiomics/ngtdm.py
+++ b/radiomics/ngtdm.py
@@ -98,7 +98,7 @@ class RadiomicsNGTDM(base.RadiomicsFeaturesBase):
 
     # Set voxels outside delineation to padding value
     padVal = numpy.nan
-    self.matrix[(self.maskArray != self.label)] = padVal
+    self.matrix[(self.maskArray == 0)] = padVal
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
     angles = imageoperations.generateAngles(size)


### PR DESCRIPTION
Erroneously tries to find voxels outside segmentation by looking for elements in `self.maskArray` not equal to `self.label`. However, `self.maskArray` is a boolean array, where elements that have label `self.label` are set to 1. This only produces an error if label is not equal to 1.

Fix: Find voxels outside segmentation by checking `self.maskArray == 0`.