### PR TITLE
setup: use scikit-build for building cmatrices and cshape C extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,14 @@ jobs:
           name: Install pyradiomics in Python 2 and 3
           command: |
             source activate python2
+            python -m pip install -U cmake
+            python -m pip install -U scikit-build
             python -m pip install --no-cache-dir -r requirements.txt
             python -m pip install --no-cache-dir -r requirements-dev.txt
             python setup.py install
             source activate root
+            python -m pip install -U cmake
+            python -m pip install -U scikit-build
             python -m pip install --no-cache-dir -r requirements.txt
             python -m pip install --no-cache-dir -r requirements-dev.txt
             python setup.py install

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# scikit-build
+_skbuild
+MANIFEST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(radiomics)
+
+find_package(PythonInterp REQUIRED)
+find_package(PythonLibs REQUIRED)
+find_package(PythonExtensions REQUIRED)
+
+add_subdirectory(radiomics/src)

--- a/radiomics/src/CMakeLists.txt
+++ b/radiomics/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(NumPy REQUIRED)
+
+add_library(_cmatrices MODULE _cmatrices.c cmatrices.c)
+python_extension_module(_cmatrices)
+target_include_directories(_cmatrices PRIVATE ${NumPy_INCLUDE_DIR})
+
+add_library(_cshape MODULE _cshape.c cshape.c)
+python_extension_module(_cshape)
+target_include_directories(_cshape PRIVATE ${NumPy_INCLUDE_DIR})
+
+install(TARGETS _cmatrices _cshape LIBRARY DESTINATION radiomics)

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -28,9 +28,8 @@ install:
   commands:
     - python --version
     - python -m pip install --disable-pip-version-check --upgrade pip
-    - $<RUN_ENV> pip install wheel>=0.29.0
-    - $<RUN_ENV> pip install setuptools>=38.6.0
-    - $<RUN_ENV> pip install numpy>=1.9.2
+    - $<RUN_ENV> pip install -U scikit-build
+    - $<RUN_ENV> pip install -U cmake
     - $<RUN_ENV> pip install --trusted-host www.itk.org -f https://itk.org/SimpleITKDoxygen/html/PyDownloadPage.html SimpleITK>=0.9.1
     - $<RUN_ENV> python -c "import SimpleITK; print('SimpleITK Version:' + SimpleITK.Version_VersionString())"
     - $<RUN_ENV> pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import platform
 import sys
 
 from setuptools.command.test import test as TestCommand
-
 import versioneer
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python
 
-from distutils import sysconfig
+from __future__ import print_function
+
 import platform
 import sys
 
-import numpy
-from setuptools import Extension, setup
 from setuptools.command.test import test as TestCommand
+
 import versioneer
+
+try:
+    from skbuild import setup
+except ImportError:
+    print('scikit-build is required to build from source.', file=sys.stderr)
+    print('Please run:', file=sys.stderr)
+    print('', file=sys.stderr)
+    print('  python -m pip install scikit-build')
+    sys.exit(1)
 
 # Check if current PyRadiomics is compatible with current python installation (> 2.6, 64 bits)
 if sys.version_info < (2, 6, 0):
@@ -55,13 +64,6 @@ class NoseTestCommand(TestCommand):
 commands = versioneer.get_cmdclass()
 commands['test'] = NoseTestCommand
 
-incDirs = [sysconfig.get_python_inc(), numpy.get_include()]
-
-ext = [Extension("radiomics._cmatrices", ["radiomics/src/_cmatrices.c", "radiomics/src/cmatrices.c"],
-                 include_dirs=incDirs),
-       Extension("radiomics._cshape", ["radiomics/src/_cshape.c", "radiomics/src/cshape.c"],
-                 include_dirs=incDirs)]
-
 setup(
   name='pyradiomics',
 
@@ -80,7 +82,6 @@ setup(
   cmdclass=commands,
 
   packages=['radiomics', 'radiomics.scripts'],
-  ext_modules=ext,
   zip_safe=False,
   package_data={'radiomics': ['schemas/paramSchema.yaml', 'schemas/schemaFuncs.py']},
 


### PR DESCRIPTION
See #283

This commit introduces new dependencies: "scikit-built" and "cmake".

scikit-build is a drop-in replacement to setuptools.setup function
allowing to easily compile and package extensions (C/C++/Cython) by
bridging CMake and setuptools. See http://scikit-build.org

CMake is is an open-source, cross-platform family of tools designed
to build, test and package software. See https://cmake.org

Currently, scikit-build and cmake have to be explicitly (see [1]) installed
on the system. This could be done by simply doing:

  pip install -U scikit-build cmake

How does it work ?
------------------

In addition to simplifying setup.py, two new file have been added:

```
<root>
  |
  |---- CMakeLists.txt                          (1)
  .
  .
  .
  |--- ...src
  |        |--- CMakeLists.txt                  (2)
  .
  .
```

The first CMakeLists.txt specifies requirements for

* Python interpreter,

* the associated python libraries

* and a "PythonExtension" modules containing convenience CMake
  functions allowing to easily build extension by encapsulating
  system introspection and platform specific logic.

and include the subdirectory associated with the other CMakeLists.txt.

The second CMakeLists.txt is specific to "cmatrices" and "cshape"
extensions and it specifies:

* requirement for NumPy

Then, it declares:

* libraries for each extension, associate python extension specific properties

* and finally add an install rule specifying where in the package
  hierarchy the extension should be installed.

Et voila,

[1] Note that improvement to python packaging will be available shortly and
it will be possible to include scikit-build and cmake directly in pyproject.toml
See here for more details: https://www.python.org/dev/peps/pep-0518/