### PR TITLE
Add PyRadiomics Models

### DIFF
--- a/bin/testParams.py
+++ b/bin/testParams.py
@@ -3,25 +3,55 @@
 # custom parameters specified will be printed. If validation fails, an error message specifying cause of validation
 # error will be printed.
 
-import sys
+import argparse
 
 import pykwalify.core
 
 from radiomics import getParameterValidationFiles
 
-def main(paramsFile):
-  schemaFile, schemaFuncs = getParameterValidationFiles()
 
-  c = pykwalify.core.Core(source_file=paramsFile, schema_files=[schemaFile], extensions=[schemaFuncs])
+def main(paramsFile, is_model=False):
+  if is_model:
+    validate_model_file(paramsFile)
+  else:
+    validate_customization(paramsFile)
+
+
+def validate_model_file(model_file):
+  schema_data, schemaFuncs = getParameterValidationFiles(is_model_validation=True)
+  c = pykwalify.core.Core(source_file=model_file, schema_data=schema_data, extensions=[schemaFuncs])
+
+  try:
+    params = c.validate()
+    print('Model validation successfull!\n\n'
+          '###Model Type###\n%s\n'
+          % (params['model']['name']))
+  except pykwalify.core.SchemaError as e:
+    print('Parameter validation failed!\n%s' % e.msg)
+
+
+def validate_customization(parameter_file):
+  schema_data, schemaFuncs = getParameterValidationFiles()
+  c = pykwalify.core.Core(source_file=parameter_file, schema_data=schema_data, extensions=[schemaFuncs])
+
   try:
     params = c.validate()
     print('Parameter validation successfull!\n\n'
           '###Enabled Features###\n%s\n'
           '###Enabled Image Types###\n%s\n'
-          '###Settings###\n%s' % (params['featureClass'], params['imageType'], params['setting']))
-  except Exception as e:
-    print('Parameter validation failed!\n%s' % e.message)
+          '###Settings###\n%s' % (params['featureClass'], params['imageType'], params['setting'])
+          )
+  except pykwalify.core.SchemaError as e:
+    print('Parameter validation failed!\n%s' % e.msg)
 
 
-if __name__ == '__main__' and len(sys.argv) > 1:
-    main(sys.argv[1])
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument('parameter_file', help='File representing the yaml or json structured configuration file to be '
+                                             'tested')
+  parser.add_argument('--model', '-m', action='store_true',
+                      help='If this argument is specified, the configuration file is treated as a PyRadiomics Model, '
+                           'otherwise, it is treated as an extraction parameter file')
+
+  args = parser.parse_args()
+  main(args.parameter_file, args.model)

--- a/examples/exampleModels/exampleModel.yaml
+++ b/examples/exampleModels/exampleModel.yaml
@@ -1,0 +1,41 @@
+# This is an example of how a PyRadiomics Model looks like.
+# It consists of 2 main parts: "extraction" and "model"
+#
+# "extraction": this part defines the settings PyRadiomics needs to extract the required features for the input.
+# A model can incorporate features extracted from different images (e.g. multiple time points, or different MR
+# sequences). For each image, a customized extraction may be defined by providing the image name as a key, and the
+# customization as a value. This customization value must adhere to the same rules as a parameter file.
+# In addition, extraction parameters that are common to all input images can be defined under "general". Be aware,
+# "general" is therefore not allowed as an image name.
+# If an image name is provided in the model, but not included in the extraction settings, no additional customization
+# is applied for that image (just the general settings, if present)
+#
+# "model": this part provides all needed information to build the model. In this case, a simple linear regression model
+# is shown. Both the "name" key (identifying the model type) and "parameters" key (providing model specific parameters)
+# are required. What kind of parameters are possible/required depends on the model. In this case, only the intercept of
+# the model and the betas (slopes) of the included features are required.
+
+extraction:
+  general:
+    setting:
+      binWidth: 25
+    imageType:
+      Original: {}
+
+  image1:
+    featureClass:
+      glcm:
+        - Dissimilarity
+
+  image2:
+    featureClass:
+      firstorder:
+        - Mean
+
+model:
+  name: linearregression
+  parameters:
+    intercept: 0.334
+    betas:
+      image1_original_glcm_Dissimilarity: 0.1
+      image2_original_firstorder_Mean: 0.3

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -148,9 +148,9 @@ class RadiomicsFeaturesExtractor:
       # No handler available for either pykwalify or root logger, provide first radiomics handler (outputs to stderr)
       pykwalify.core.log.addHandler(logging.getLogger('radiomics').handlers[0])
 
-    schemaFile, schemaFuncs = getParameterValidationFiles()
+    schema_data, schemaFuncs = getParameterValidationFiles()
     c = pykwalify.core.Core(source_file=paramsFile, source_data=paramsDict,
-                            schema_files=[schemaFile], extensions=[schemaFuncs])
+                            schema_data=schema_data, extensions=[schemaFuncs])
     params = c.validate()
     self.logger.debug('Parameters parsed, input is valid.')
 

--- a/radiomics/schemas/modelSchema.yaml
+++ b/radiomics/schemas/modelSchema.yaml
@@ -1,0 +1,22 @@
+#  include: customization_schema
+name: model_schema
+type: map
+mapping:
+  extraction:
+    type: map
+    mapping:
+      regex;(.+):
+        include: customization_schema
+  model:
+    type: map
+    required: true
+    mapping:
+      name:
+        type: str
+        required: true
+      parameters:
+        type: map
+        required: true
+        mapping:
+          regex;(.+):
+            type: any

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -1,153 +1,154 @@
 # Parameters schema
-name: Parameter schema
-desc: This schema defines what arguments may be present in the parameters file that can be passed to the pyradiomics package.
-type: map
-mapping:
-  setting: &settings
-    type: map
-    mapping:
-      minimumROIDimensions:
-        type: int
-        range:
-          min: 1
-          max: 3
-      minimumROISize:
-        type: int
-        range:
-          min-ex: 0
-      geometryTolerance:
-        type: float
-        range:
-          min-ex: 0
-      correctMask:
-        type: bool
-      additionalInfo:
-        type: bool
-      label:
-        type: int
-      binWidth:
-        type: float
-        range:
-          min-ex: 0
-      binCount:
-        type: int
-        range:
-          min-ex: 0
-      normalize:
-        type: bool
-      normalizeScale:
-        type: float
-        range:
-          min-ex: 0
-      removeOutliers:
-        type: float
-        range:
-          min-ex: 0
-      resampledPixelSpacing:
-        seq:
-          - type: float
-            range:
-              min: 0
-      interpolator:
-        type: any
-        func: checkInterpolator
-      padDistance:
-        type: int
-        range:
-          min: 0
-      distances:
-        seq:
-          - type: int
-            range:
-              min-ex: 0
-      force2D:
-        type: bool
-      force2Ddimension:
-        type: int
-        range:
-          min: 0
-          max: 2
-      resegmentRange:
-        seq:
-          - type: float
-      preCrop:
-        type: bool
-      sigma:
-        seq:
-          - type: float
-            range:
-              min-ex: 0
-      start_level:
-        type: int
-        range:
-          min: 0
-      level:
-        type: int
-        range:
-          min-ex: 0
-      wavelet:
-        type: str
-        func: checkWavelet
-      gradientUseSpacing:
-        type: bool
-      lbp2DRadius:
-        type: float
-        range:
-          min-ex: 0
-      lbp2DSamples:
-        type: int
-        range:
-          min: 1
-      lbp2DMethod:
-        type: str
-        enum: ['default', 'ror', 'uniform', 'var']
-      lbp3DLevels:
-        type: int
-        range:
-          min: 1
-      lbp3DIcosphereRadius:
-        type: float
-        range:
-          min-ex: 0
-      lbp3DIcosphereSubdivision:
-        type: int
-        range:
-          min: 0
-      voxelArrayShift:
-        type: int
-      symmetricalGLCM:
-        type: bool
-      weightingNorm:
-        type: any
-        func: checkWeighting
-      gldm_a:
-        type: int
-        range:
-          min: 0
+schema;customization_schema:
+  name: Parameter schema
+  desc: This schema defines what arguments may be present in the parameters file that can be passed to the pyradiomics package.
+  type: map
+  mapping:
+    setting: &settings
+      type: map
+      mapping:
+        minimumROIDimensions:
+          type: int
+          range:
+            min: 1
+            max: 3
+        minimumROISize:
+          type: int
+          range:
+            min-ex: 0
+        geometryTolerance:
+          type: float
+          range:
+            min-ex: 0
+        correctMask:
+          type: bool
+        additionalInfo:
+          type: bool
+        label:
+          type: int
+        binWidth:
+          type: float
+          range:
+            min-ex: 0
+        binCount:
+          type: int
+          range:
+            min-ex: 0
+        normalize:
+          type: bool
+        normalizeScale:
+          type: float
+          range:
+            min-ex: 0
+        removeOutliers:
+          type: float
+          range:
+            min-ex: 0
+        resampledPixelSpacing:
+          seq:
+            - type: float
+              range:
+                min: 0
+        interpolator:
+          type: any
+          func: checkInterpolator
+        padDistance:
+          type: int
+          range:
+            min: 0
+        distances:
+          seq:
+            - type: int
+              range:
+                min-ex: 0
+        force2D:
+          type: bool
+        force2Ddimension:
+          type: int
+          range:
+            min: 0
+            max: 2
+        resegmentRange:
+          seq:
+            - type: float
+        preCrop:
+          type: bool
+        sigma:
+          seq:
+            - type: float
+              range:
+                min-ex: 0
+        start_level:
+          type: int
+          range:
+            min: 0
+        level:
+          type: int
+          range:
+            min-ex: 0
+        wavelet:
+          type: str
+          func: checkWavelet
+        gradientUseSpacing:
+          type: bool
+        lbp2DRadius:
+          type: float
+          range:
+            min-ex: 0
+        lbp2DSamples:
+          type: int
+          range:
+            min: 1
+        lbp2DMethod:
+          type: str
+          enum: ['default', 'ror', 'uniform', 'var']
+        lbp3DLevels:
+          type: int
+          range:
+            min: 1
+        lbp3DIcosphereRadius:
+          type: float
+          range:
+            min-ex: 0
+        lbp3DIcosphereSubdivision:
+          type: int
+          range:
+            min: 0
+        voxelArrayShift:
+          type: int
+        symmetricalGLCM:
+          type: bool
+        weightingNorm:
+          type: any
+          func: checkWeighting
+        gldm_a:
+          type: int
+          range:
+            min: 0
 
-  voxelSetting:
-    type: map
-    mapping:
-      kernelRadius:
-        type: int
-        range:
-          min-ex: 0
-      maskedKernel:
-        type: bool
-      initValue:
-        type: float
+    voxelSetting:
+      type: map
+      mapping:
+        kernelRadius:
+          type: int
+          range:
+            min-ex: 0
+        maskedKernel:
+          type: bool
+        initValue:
+          type: float
 
-  featureClass:
-    type: map
-    func: checkFeatureClass
-    matching-rule: 'any'
-    mapping:
-      regex;(.+):
-        type: any
+    featureClass:
+      type: map
+      func: checkFeatureClass
+      matching-rule: 'any'
+      mapping:
+        regex;(.+):
+          type: any
 
-  imageType:
-    type: map
-    func: checkImageType
-    matching-rule: 'any'
-    mapping:
-       regex;(.+): *settings
+    imageType:
+      type: map
+      func: checkImageType
+      matching-rule: 'any'
+      mapping:
+         regex;(.+): *settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.9.2
 SimpleITK>=0.9.1
 PyWavelets>=0.4.0
-pykwalify>=1.6.0
+pykwalify!=1.6.0
 six>=1.10.0

--- a/tests/test_exampleSettings.py
+++ b/tests/test_exampleSettings.py
@@ -16,7 +16,7 @@ def exampleSettings_name_func(testcase_func, param_num, param):
 
 class TestExampleSettings:
   def __init__(self):
-    self.schemaFile, self.schemaFuncs = getParameterValidationFiles()
+    self.schema_data, self.schemaFuncs = getParameterValidationFiles()
 
   def generateScenarios():
     dataDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'examples', 'exampleSettings')
@@ -29,7 +29,5 @@ class TestExampleSettings:
   @parameterized.expand(generateScenarios(), testcase_func_name=exampleSettings_name_func)
   def test_scenarios(self, settingsFile):
 
-    assert os.path.isfile(self.schemaFile)
-    assert os.path.isfile(self.schemaFuncs)
-    c = pykwalify.core.Core(source_file=settingsFile, schema_files=[self.schemaFile], extensions=[self.schemaFuncs])
+    c = pykwalify.core.Core(source_file=settingsFile, schema_data=self.schema_data, extensions=[self.schemaFuncs])
     c.validate()


### PR DESCRIPTION
The first commit only defines an example for the model configuration file and adds some code to validate these using PyKwalify:
- Update the PyKwalify validation in PyRadiomics to also allow validation of PyRadiomics model files.
- Add an example model file to explain the structure.
- Update requirements.txt to enforce PyKwalify version != 1.6.0, as this version contains a bug that breaks the usage of partial schemas, which is utilized to allow validation of the two use cases (parameter file and model file) **N.B. in the previous version (1.5.2) PyKwalify contains a bug that resets the output to stdout upon loading the package. This means that when using jupyter notebooks, the output does not show in the notebook, but in the commandline running jupyter!**
- Because partial schemas are used, load the schemas outside of pykwalify and pass them during validation as a dict. (Enables customized schema dict reflecting the two use cases)
- Update the testParams script to allow testing of both use cases.

TODO:
- [ ] add functionality to apply a model (i.e. extract features, parse results and call model specific modules to apply the actual model.
- [ ] add several modules containing model specific code (for example to apply linear or logistic regression)
- [ ] design unit tests for the new functionality
- [ ] update test-settings test to allow testing of model configuration files
- [ ] add command line interface to make new functionality available to the user
- [ ] update documentation
- [ ] build slicer module to make new functionality available in slicer (not in this PR)

cc @Radiomics/developers 