### PR TITLE
Expose mask correction and geometry tolerance to the pyradiomics-dcm CLI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,13 @@ Internal API
 - Add optional progress reporting for voxel-based extraction.
   (`#636 <https://github.com/Radiomics/pyradiomics/pull/636>`_)
 
+Labs
+####
+
+- Expose mask correction and geometry tolerance settings in pyradiomics-dcm CLI
+  (`#724 <https://github.com/AIM-Harvard/pyradiomics/pull/724>`_)
+
+
 ---------------
 PyRadiomics 3.0
 ---------------

--- a/labs/pyradiomics-dcm/README.md
+++ b/labs/pyradiomics-dcm/README.md
@@ -48,25 +48,25 @@ Support for DICOM Radiotherapy Structure Sets for defining region of interest ma
 
 optional arguments:
   -h, --help            show this help message and exit
-  --input-image-dir (path to input DICOM directory)
-                        Directory with the input DICOM series. It is expected that a single series is
-                        corresponding to a single scalar volume.
-  --input-seg-file <path to input DICOM SEG file>
-                        Input segmentation defined as a DICOM Segmentation object.
-  --output-dir <path to output directory>
-                        Directory for saving the resulting DICOM file.
-  --parameters <Pyradiomics extraction parameters>
-                        Feature extractor positional arguments
-  --temp-dir <path to temporary directory>
-                        Directory to store intermediate results
-  --features-dict <path to features dictionary file>
-                        Dictionary mapping pyradiomics feature names to the IBSI defined features.
+  --input-image-dir <folder>
+                        Path to the directory with the input DICOM series. It is expected that a single
+                        series is corresponding to a single scalar volume.
+  --input-seg-file <file>
+                        Path to the input segmentation defined as a DICOM Segmentation object.
+  --output-dir <folder>
+                        Path to the directory for saving the resulting DICOM file.
+  --parameters <parameters>
+                        Pyradiomics feature extractor positional arguments
+  --temp-dir <folder>   Path to the directory to store intermediate results
+  --features-dict <file>
+                        Path to the dictionary mapping pyradiomics feature names to the IBSI defined
+                        features.
   --volume-reconstructor <plastimatch or dcm2niix>
                         Choose the tool to be used for reconstructing image volume from the DICOM image
                         series. Allowed options are plastimatch or dcm2niix (should be installed on the
                         system). plastimatch will be used by default.
-  --geometry-tolerance <decimal number>
-                        Geometry tolerance setting for the extractor. Defaults to 1e-6.
+  --geometry-tolerance <number>
+                        Decimal number setting geometry tolerance for the extractor. Defaults to 1e-6.
   --correct-mask        Boolean flag argument. If present, PyRadiomics will attempt to resample the mask
                         to the image geometry if the mask check fails.
 ```

--- a/labs/pyradiomics-dcm/README.md
+++ b/labs/pyradiomics-dcm/README.md
@@ -48,19 +48,27 @@ Support for DICOM Radiotherapy Structure Sets for defining region of interest ma
 
 optional arguments:
   -h, --help            show this help message and exit
-  --input-image-dir Input DICOM image directory
-                        Directory with the input DICOM series. It is expected
-                        that a single series is corresponding to a single
-                        scalar volume.
-  --input-seg-file Input DICOM SEG file
-                        Input segmentation defined as aDICOM Segmentation
-                        object.
-  --output-dir Directory to store the output file
+  --input-image-dir (path to input DICOM directory)
+                        Directory with the input DICOM series. It is expected that a single series is
+                        corresponding to a single scalar volume.
+  --input-seg-file <path to input DICOM SEG file>
+                        Input segmentation defined as a DICOM Segmentation object.
+  --output-dir <path to output directory>
                         Directory for saving the resulting DICOM file.
-  --parameters pyradiomics extraction parameters
-  --temp-dir Temporary directory
-  --features-dict Dictionary mapping pyradiomics feature names to the IBSI defined features.
-  --volume-reconstructor Choose the tool to be used for reconstructing image volume from the DICOM image series. Allowed options are plastimatch or dcm2niix (should be installed on the system). plastimatch will be used by default.
+  --parameters <Pyradiomics extraction parameters>
+                        Feature extractor positional arguments
+  --temp-dir <path to temporary directory>
+                        Directory to store intermediate results
+  --features-dict <path to features dictionary file>
+                        Dictionary mapping pyradiomics feature names to the IBSI defined features.
+  --volume-reconstructor <plastimatch or dcm2niix>
+                        Choose the tool to be used for reconstructing image volume from the DICOM image
+                        series. Allowed options are plastimatch or dcm2niix (should be installed on the
+                        system). plastimatch will be used by default.
+  --geometry-tolerance <decimal number>
+                        Geometry tolerance setting for the extractor. Defaults to 1e-6.
+  --correct-mask        Boolean flag argument. If present, PyRadiomics will attempt to resample the mask
+                        to the image geometry if the mask check fails.
 ```
 
 # Sample invocation

--- a/labs/pyradiomics-dcm/pyradiomics-dcm.py
+++ b/labs/pyradiomics-dcm/pyradiomics-dcm.py
@@ -320,49 +320,52 @@ class TID1500Metadata:
 def main():
   parser = argparse.ArgumentParser(
     usage="%(prog)s --input-image <dir> --input-seg <name> --output-sr <name>\n\n"
-          "Warning: This is a \"pyradiomics labs\" script, which means it is an experimental feature in development!\n"
-          "The intent of this helper script is to enable pyradiomics feature extraction directly from/to DICOM data.\n"
-          "The segmentation defining the region of interest must be defined as a DICOM Segmentation image.\n"
-          "Support for DICOM Radiotherapy Structure Sets for defining region of interest may be added in the future.\n")
+          + "Warning: This is a \"pyradiomics labs\" script, which means it is an experimental feature in development!\n"
+          + "The intent of this helper script is to enable pyradiomics feature extraction directly from/to DICOM data.\n"
+          + "The segmentation defining the region of interest must be defined as a DICOM Segmentation image.\n"
+          + "Support for DICOM Radiotherapy Structure Sets for defining region of interest may be added in the future.\n")
   parser.add_argument(
     '--input-image-dir',
     dest="inputDICOMImageDir",
-    metavar='Input DICOM image directory',
-    help="Directory with the input DICOM series."
-         " It is expected that a single series is corresponding to a single scalar volume.",
+    metavar="<folder>",
+    help="Path to the directory with the input DICOM series."
+         + " It is expected that a single series is corresponding to a single scalar volume.",
     required=True)
   parser.add_argument(
     '--input-seg-file',
     dest="inputSEG",
-    metavar='Input DICOM SEG file',
-    help="Input segmentation defined as a"
-         "DICOM Segmentation object.",
+    metavar="<file>",
+    help="Path to the input segmentation defined as a DICOM Segmentation object.",
     required=True)
   parser.add_argument(
     '--output-dir',
     dest="outputDir",
-    metavar='Directory to store the output file',
-    help="Directory for saving the resulting DICOM file.",
+    metavar="<folder>",
+    help="Path to the directory for saving the resulting DICOM file.",
     required=True)
   parser.add_argument(
     '--parameters',
     dest="parameters",
-    metavar="pyradiomics extraction parameters")
+    metavar="<parameters>",
+    help="Pyradiomics feature extractor positional arguments")
   parser.add_argument(
     '--temp-dir',
     dest="tempDir",
-    metavar="Temporary directory")
+    metavar="<folder>",
+    help="Path to the directory to store intermediate results")
   parser.add_argument(
     '--features-dict',
     dest="featuresDict",
-    metavar="Dictionary mapping pyradiomics feature names to the IBSI defined features.")
+    metavar="<file>",
+    help="Path to the dictionary mapping pyradiomics feature names to the IBSI defined features.")
   parser.add_argument(
     '--volume-reconstructor',
     dest="volumeReconstructor",
-    metavar="Choose the tool to be used for reconstructing image volume from the DICOM image series."
-            " Allowed options are plastimatch or dcm2niix (should be installed on the system). plastimatch "
-            "will be used by default.",
-    choices=['plastimatch', 'dcm2nixx'],
+    metavar="<plastimatch or dcm2niix>",
+    help="Choose the tool to be used for reconstructing image volume from the DICOM image series."
+         + " Allowed options are plastimatch or dcm2niix (should be installed on the system). plastimatch"
+         + " will be used by default.",
+    choices=['plastimatch', 'dcm2niix'],
     default="plastimatch")
   parser.add_argument(
     '--geometry-tolerance',

--- a/labs/pyradiomics-dcm/pyradiomics-dcm.py
+++ b/labs/pyradiomics-dcm/pyradiomics-dcm.py
@@ -364,6 +364,19 @@ def main():
             "will be used by default.",
     choices=['plastimatch', 'dcm2nixx'],
     default="plastimatch")
+  parser.add_argument(
+    '--geometry-tolerance',
+    dest="geometryTolerance",
+    metavar="<number>",
+    help="Decimal number setting geometry tolerance for the extractor. Defaults to 1e-6.",
+    default=1e-6)
+  parser.add_argument(
+    '--correct-mask',
+    dest="correctMask",
+    help="Boolean flag argument. If present, PyRadiomics will attempt to resample the mask to the image"
+         + " geometry if the mask check fails.",
+    action='store_true',
+    default=False)
 
   args = parser.parse_args()
 
@@ -440,17 +453,14 @@ def main():
 
     try:
       scriptlogger.debug("Initializing extractor")
-      # TODO: most likely, there will be geometric inconsistencies that will throw
-      # pyradiomics off by exceeding the default tolerance. Need to decide if we
-      # should always resample, or set tolerance to a larger number, or expose in
-      # the command line.
-      correctMaskSetting = {}
-      correctMaskSetting["setting"] = {
-        "geometryTolerance": 0.001, "correctMask": True}
+      extractionSettings = {
+        "geometryTolerance": float(args.geometryTolerance),
+        "correctMask": True if args.correctMask else False
+      }
       params = []
       if args.parameters is not None:
         params = [args.parameters]
-      extractor = featureextractor.RadiomicsFeatureExtractor(*params, **correctMaskSetting)
+      extractor = featureextractor.RadiomicsFeatureExtractor(*params, **extractionSettings)
 
     except Exception:
       scriptlogger.error(


### PR DESCRIPTION
This PR exposes `geometryTrolerance` and `correctMask` extractor settings to the CLI of `pyradiomics-dcm` making it possible to process to process images that raise an `'Image/Mask geometry mismatch'` error.

The default parameters are the same as the default parameters in `sitk` and `pyradiomics`:
- `geometryTolerance` is [1e-6](https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1ProcessObject.html#a61dc7bc36a573d0f4a133bca60ed598c)
- `correctMask` is [False](https://pyradiomics.readthedocs.io/en/latest/customization.html?highlight=correctMask#feature-extractor-level)

---

- [x] Update documentation
- [x] Update Changelog for the next release