### PR TITLE
fix: label assignment for feature extraction

### DIFF
--- a/examples/batchprocessing_parallel.py
+++ b/examples/batchprocessing_parallel.py
@@ -114,7 +114,7 @@ def run(case):
       extractor = RadiomicsFeatureExtractor(PARAMS)
 
       # Extract features
-      feature_vector.update(extractor.execute(imageFilepath, maskFilepath), label=label)
+      feature_vector.update(extractor.execute(imageFilepath, maskFilepath, label=label))
 
       # Store results in temporary separate files to prevent write conflicts
       # This allows for the extraction to be interrupted. Upon restarting, already processed cases are found in the


### PR DESCRIPTION
In the example for parallel batch processing: If the user passes a label column in the input CSV, the fetched label does not get passed to the feature extractor. This leads to extracting features of the same label, even if different labels are provided in the CSV file.
The non-parallel versions already do this correctly. 