### PR TITLE
Defer numpy import on first pass of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,13 @@
 from distutils import sysconfig
 import platform
 
-import numpy
+try:
+    import numpy
+except:  # noqa: E722
+    from unittest.mock import MagicMock
+    sys.modules["numpy"] = MagicMock()
+    import numpy
+
 from setuptools import Extension, setup
 import versioneer
 


### PR DESCRIPTION
This PR addresses #653  by ensuring that `numpy` is not required on the first pass of `setup.py`.  This makes `pyradiomics` easy to install into new virtual environments without having an a priori installation of numpy.

The update is based on the fact that setuptools invokes `setup.py` multiple times, and on the first pass, you must guard import statements of modules in the `setup_requires` section.   We can therefore mock out the `numpy` module on the first pass, which should not affect the subsequent installation steps after the build system has fetched numpy and installed it.