### PR TITLE
BUG: Update CI and tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include requirements-dev.txt
 include requirements-setup.txt
 include versioneer.py
 
-recursive-include radiomics *
+recursive-include src/radiomics *
 
 recursive-include data/baseline *
 recursive-include data *_image.nrrd
@@ -24,4 +24,3 @@ recursive-include bin *.py
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[cod]
-recursive-exclude * nosetests.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=61.0", "numpy", "versioneer"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyradiomics"
+version = "3.0.1a1"
+authors = [
+    { name = "PyRadimiomics Community", email = "pyradiomics@googlegroups.com"}
+]
+description = "Radiomics features library for python"
+readme = "README.md"
+requires-python =">=3.5"
+license = { file = "LICENSE.txt"}
+keywords = [ "radiomics", "cancerimaging", "medicalresearch", "computationalimaging" ]
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Environment :: Console',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: BSD License',
+    'Operating System :: OS Independent',
+    'Programming Language :: C',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Topic :: Scientific/Engineering :: Bio-Informatics'
+]
+dependencies = [
+    "numpy",
+    "SimpleITK",
+    "PyWavelets",
+    "pykwalify",
+    "six"
+]
+
+[project.scripts]
+pyradiomics = "radiomics.scripts.__init__:parse_args"
+
+[project.urls]
+"Homepaget" = "http://github.com/AIM-Harvard/pyradiomics#readme"
+"Radiomics.io" = "https://www.radiomics.io/"
+"Documentation" = "https://pyradiomics.readthedocs.io/en/latest/index.html"
+"Docker" = "https://hub.docker.com/r/radiomics/pyradiomics/"
+"Github" = "https://github.com/AIM-Harvard/pyradiomics"

--- a/radiomics/generalinfo.py
+++ b/radiomics/generalinfo.py
@@ -113,8 +113,8 @@ class GeneralInfo:
     lssif = sitk.LabelShapeStatisticsImageFilter()
     lssif.Execute(mask)
 
-    self.generalInfo[self.generalInfo_prefix + 'Mask-' + prefix + '_BoundingBox'] = lssif.GetBoundingBox(label)
-    self.generalInfo[self.generalInfo_prefix + 'Mask-' + prefix + '_VoxelNum'] = lssif.GetNumberOfPixels(label)
+    self.generalInfo[self.generalInfo_prefix + 'Mask-' + prefix + '_BoundingBox'] = lssif.GetBoundingBox(int(label))
+    self.generalInfo[self.generalInfo_prefix + 'Mask-' + prefix + '_VoxelNum'] = lssif.GetNumberOfPixels(int(label))
 
     labelMap = (mask == label)
     ccif = sitk.ConnectedComponentImageFilter()

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -19,6 +19,13 @@ def getMask(mask, **kwargs):
   In this case, the mask at index ``label_channel`` is extracted. The resulting 3D volume is then treated as it were a
   scalar input volume (i.e. with the region of interest defined by voxels with value matching ``label``).
 
+  .. note::
+    If only one or non-overlapping Segments are defined when using 3D Slicer, it may be the case that it is stored as a
+    labelmap (i.e. only 1 ``label_channel``, with different segmentations identified by different values for ``label``).
+    This is easy to check by loading the mask as a SimpleITK image and checking the `GetNumberOfComponentsPerPixel()`,
+    if the return value is ``1``, it is a label map (i.e. use ``label``), otherwise it is a VectorImage (i.e. use
+    ``label_channel``).
+
   Finally, checks if the mask volume contains an ROI identified by ``label``. Raises a value error if the label is not
   present (including a list of valid labels found).
 
@@ -38,7 +45,7 @@ def getMask(mask, **kwargs):
 
     logger.info('Extracting mask at index %i', label_channel)
     selector = sitk.VectorIndexSelectionCastImageFilter()
-    selector.SetIndex(label_channel)
+    selector.SetIndex(int(label_channel))
     mask = selector.Execute(mask)
 
   logger.debug('Force casting mask to UInt32 to ensure correct datatype.')
@@ -216,7 +223,7 @@ def checkMask(imageNode, maskNode, **kwargs):
 
   correctedMask = None
 
-  label = kwargs.get('label', 1)
+  label = int(kwargs.get('label', 1))
   minDims = kwargs.get('minimumROIDimensions', 2)
   minSize = kwargs.get('minimumROISize', None)
 
@@ -316,7 +323,7 @@ def _checkROI(imageNode, maskNode, **kwargs):
   returned. Otherwise, a ValueError is raised.
   """
   global logger
-  label = kwargs.get('label', 1)
+  label = int(kwargs.get('label', 1))
 
   logger.debug('Checking ROI validity')
 
@@ -442,7 +449,7 @@ def resampleImage(imageNode, maskNode, **kwargs):
   resampledPixelSpacing = kwargs['resampledPixelSpacing']
   interpolator = kwargs.get('interpolator', sitk.sitkBSpline)
   padDistance = kwargs.get('padDistance', 5)
-  label = kwargs.get('label', 1)
+  label = int(kwargs.get('label', 1))
 
   logger.debug('Resampling image and mask')
 

--- a/radiomics/scripts/__init__.py
+++ b/radiomics/scripts/__init__.py
@@ -15,6 +15,7 @@ from pykwalify.compat import yaml
 import pykwalify.core
 import six.moves
 
+import radiomics
 import radiomics.featureextractor
 from . import segment, voxel
 

--- a/radiomics/scripts/segment.py
+++ b/radiomics/scripts/segment.py
@@ -8,7 +8,7 @@ import threading
 import SimpleITK as sitk
 import six
 
-import radiomics.featureextractor
+import radiomics
 
 caseLogger = logging.getLogger('radiomics.script')
 _parallel_extraction_configured = False

--- a/radiomics/scripts/voxel.py
+++ b/radiomics/scripts/voxel.py
@@ -7,7 +7,7 @@ import threading
 import SimpleITK as sitk
 import six
 
-import radiomics.featureextractor
+import radiomics
 
 caseLogger = logging.getLogger('radiomics.script')
 _parallel_extraction_configured = False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
-nose>=1.3.7
-parameterized
+pytest
 flake8
 flake8-import-order
 sphinx>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.9.2
-SimpleITK>=0.9.1
-PyWavelets>=0.4.0
-pykwalify>=1.6.0
-six>=1.10.0
+numpy
+SimpleITK
+PyWavelets
+pykwalify
+six

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -45,11 +45,7 @@ build:
 
 test:
   commands:
-    - $<RUN_ENV> python setup.py test  --args="--with-xunit --logging-level=DEBUG"
-
-  circleci:
-    commands:
-      - cp nosetests.xml $CIRCLE_TEST_REPORTS
+    - $<RUN_ENV> pytest
 
 after_test:
   commands:

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -41,7 +41,7 @@ before_build:
 
 build:
   commands:
-    - $<RUN_ENV> python setup.py build_ext
+    - $<RUN_ENV> python setup.py develop
 
 test:
   commands:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,23 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
-[nosetests]
-verbosity=3
-where=tests
+[options]
+install_requires =
+    numpy
+    SimpleITK
+    PyWavelets
+    pykwalify
+    six
+include_package_data=False
+
+[options.packages.find]
+include=radiomics*
+exclude=radiomics.schemas
+
+[options.package_data]
+radiomics =
+      schemas/paramSchema.yaml
+      schemas/schemaFuncs.py
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -2,59 +2,15 @@
 
 from distutils import sysconfig
 import platform
-import sys
 
 import numpy
 from setuptools import Extension, setup
-from setuptools.command.test import test as TestCommand
 import versioneer
-
-# Check if current PyRadiomics is compatible with current python installation (> 2.6, 64 bits)
-if sys.version_info < (2, 6, 0):
-  raise Exception("pyradiomics > 0.9.7 requires python 2.6 or later")
 
 if platform.architecture()[0].startswith('32'):
   raise Exception('PyRadiomics requires 64 bits python')
 
-with open('requirements.txt', 'r') as fp:
-  requirements = list(filter(bool, (line.strip() for line in fp)))
-
-with open('requirements-dev.txt', 'r') as fp:
-  dev_requirements = list(filter(bool, (line.strip() for line in fp)))
-
-with open('requirements-setup.txt', 'r') as fp:
-  setup_requirements = list(filter(bool, (line.strip() for line in fp)))
-
-with open('README.md', 'rb') as fp:
-  long_description = fp.read().decode('utf-8')
-
-
-class NoseTestCommand(TestCommand):
-  """Command to run unit tests using nose driver after in-place build"""
-
-  user_options = TestCommand.user_options + [
-    ("args=", None, "Arguments to pass to nose"),
-  ]
-
-  def initialize_options(self):
-    self.args = []
-    TestCommand.initialize_options(self)
-
-  def finalize_options(self):
-    TestCommand.finalize_options(self)
-    if self.args:
-      self.args = __import__('shlex').split(self.args)
-
-  def run_tests(self):
-    # Run nose ensuring that argv simulates running nosetests directly
-    nose_args = ['nosetests']
-    nose_args.extend(self.args)
-    __import__('nose').run_exit(argv=nose_args)
-
-
 commands = versioneer.get_cmdclass()
-commands['test'] = NoseTestCommand
-
 incDirs = [sysconfig.get_python_inc(), numpy.get_include()]
 
 ext = [Extension("radiomics._cmatrices", ["radiomics/src/_cmatrices.c", "radiomics/src/cmatrices.c"],
@@ -65,56 +21,10 @@ ext = [Extension("radiomics._cmatrices", ["radiomics/src/_cmatrices.c", "radiomi
 setup(
   name='pyradiomics',
 
-  url='http://github.com/Radiomics/pyradiomics#readme',
-  project_urls={
-    'Radiomics.io': 'https://www.radiomics.io/',
-    'Documentation': 'https://pyradiomics.readthedocs.io/en/latest/index.html',
-    'Docker': 'https://hub.docker.com/r/radiomics/pyradiomics/',
-    'Github': 'https://github.com/Radiomics/pyradiomics'
-  },
-
-  author='pyradiomics community',
-  author_email='pyradiomics@googlegroups.com',
-
   version=versioneer.get_version(),
   cmdclass=commands,
 
   packages=['radiomics', 'radiomics.scripts'],
   ext_modules=ext,
   zip_safe=False,
-  package_data={'radiomics': ['schemas/paramSchema.yaml', 'schemas/schemaFuncs.py']},
-
-  entry_points={
-    'console_scripts': [
-      'pyradiomics=radiomics.scripts.__init__:parse_args'
-    ]},
-
-  description='Radiomics features library for python',
-  long_description=long_description,
-  long_description_content_type='text/markdown',
-
-  license='BSD License',
-
-  classifiers=[
-    'Development Status :: 5 - Production/Stable',
-    'Environment :: Console',
-    'Intended Audience :: Developers',
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: OS Independent',
-    'Programming Language :: C',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Topic :: Scientific/Engineering :: Bio-Informatics',
-  ],
-
-  keywords='radiomics cancerimaging medicalresearch computationalimaging',
-
-  install_requires=requirements,
-  test_suite='nose.collector',
-  tests_require=dev_requirements,
-  setup_requires=setup_requirements
 )

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1,11 +1,9 @@
-
 import ast
 import csv
 import logging
 import math
 import os
 
-from nose_parameterized import parameterized
 import numpy
 import SimpleITK as sitk
 import six
@@ -14,38 +12,6 @@ from radiomics import featureextractor, getTestCase, imageoperations
 
 # Get the logger. This is done outside the class, as it is needed by both the class and the custom_name_func
 logger = logging.getLogger('radiomics.testing')
-
-
-def custom_name_func(testcase_func, param_num, param):
-  """
-  A custom test name function that will ensure that the tests are run such that they're batched with all tests for a
-  given data set are run together, avoiding re-reading the data more than necessary. Tests are run in alphabetical
-  order, so put the test case first. An alternate option is to right justify the test number (param_num) with zeroes
-  so that the numerical and alphabetical orders are the same. Not providing this method when there are more than 10
-  tests results in tests running in an order similar to:
-
-  test_*.test_scenario_0_*
-
-  test_*.test_scenario_10_*
-
-  test_*.test_scenario_11_*
-
-  ...
-
-  test_*.test_scenario_19_*
-
-  test_*.test_scenario_1_*
-
-  test_*.test_scenario_20_*
-  """
-  global logger
-
-  logger.debug('custom_name_func: function name = %s, param_num = {0:0>3}, param.args = %s'.format(param_num),
-               testcase_func.__name__, param.args)
-  return str("%s_%s" % (
-    testcase_func.__name__,
-    parameterized.to_safe_name("_".join(str(x) for x in param.args)),
-  ))
 
 
 class RadiomicsTestUtils:

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,39 +1,19 @@
-# to run this test, from directory above:
-# setenv PYTHONPATH /path/to/pyradiomics/radiomics
-# nosetests --nocapture -v tests/test_docstrings.py
-
 import logging
 
-from nose_parameterized import parameterized
 import six
 
 from radiomics import getFeatureClasses
-from testUtils import custom_name_func
 
 featureClasses = getFeatureClasses()
 
 
-def setup_module(module):
-  # runs before anything in this file
-  print("")  # this is to get a newline after the dots
-  return
+def pytest_generate_tests(metafunc):
+  metafunc.parametrize(["featureClassName", "featureName"], metafunc.cls.generate_scenarios())
 
 
 class TestDocStrings:
-  def setup(self):
-    # setup before each test method
-    print("")  # this is to get a newline after the dots
 
-  @classmethod
-  def setup_class(cls):
-    # called before any methods in this class
-    print("")  # this is to get a newline after the dots
-
-  @classmethod
-  def teardown_class(cls):
-    # run after any methods in this class
-    print("")  # this is to get a newline after the dots
-
+  @staticmethod
   def generate_scenarios():
     global featureClasses
     for featureClassName, featureClass in six.iteritems(featureClasses):
@@ -45,7 +25,6 @@ class TestDocStrings:
       for f in featureNames:
         yield (featureClassName, f)
 
-  @parameterized.expand(generate_scenarios(), testcase_func_name=custom_name_func)
   def test_class(self, featureClassName, featureName):
     global featureClasses
     logging.info('%s', featureName)

--- a/tests/test_exampleSettings.py
+++ b/tests/test_exampleSettings.py
@@ -1,13 +1,14 @@
-# to run this test, from directory above:
-# setenv PYTHONPATH /path/to/pyradiomics/radiomics
-# nosetests --nocapture -v tests/test_exampleSettings.py
-
 import os
 
-from nose_parameterized import parameterized
 import pykwalify.core
 
 from radiomics import getParameterValidationFiles
+
+
+schemaFile, schemaFuncs = getParameterValidationFiles()
+
+def pytest_generate_tests(metafunc):
+  metafunc.parametrize("settingsFile", metafunc.cls.generate_scenarios())
 
 
 def exampleSettings_name_func(testcase_func, param_num, param):
@@ -15,10 +16,9 @@ def exampleSettings_name_func(testcase_func, param_num, param):
 
 
 class TestExampleSettings:
-  def __init__(self):
-    self.schemaFile, self.schemaFuncs = getParameterValidationFiles()
 
-  def generateScenarios():
+  @staticmethod
+  def generate_scenarios():
     dataDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'examples', 'exampleSettings')
     if os.path.isdir(dataDir):
       settingsFiles = [fname for fname in os.listdir(dataDir) if fname.endswith('.yaml') or fname.endswith('.yml')]
@@ -26,10 +26,10 @@ class TestExampleSettings:
       for fname in settingsFiles:
         yield os.path.join(dataDir, fname)
 
-  @parameterized.expand(generateScenarios(), testcase_func_name=exampleSettings_name_func)
   def test_scenarios(self, settingsFile):
+    global schemaFile, schemaFuncs
 
-    assert os.path.isfile(self.schemaFile)
-    assert os.path.isfile(self.schemaFuncs)
-    c = pykwalify.core.Core(source_file=settingsFile, schema_files=[self.schemaFile], extensions=[self.schemaFuncs])
+    assert os.path.isfile(schemaFile)
+    assert os.path.isfile(schemaFuncs)
+    c = pykwalify.core.Core(source_file=settingsFile, schema_files=[schemaFile], extensions=[schemaFuncs])
     c.validate()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,15 +1,10 @@
-# to run this test, from directory above:
-# setenv PYTHONPATH /path/to/pyradiomics/radiomics
-# nosetests --nocapture -v tests/test_features.py
-
 import logging
 import os
 
-from nose_parameterized import parameterized
 import six
 
 from radiomics import getFeatureClasses
-from testUtils import custom_name_func, RadiomicsTestUtils
+from testUtils import RadiomicsTestUtils
 
 testUtils = RadiomicsTestUtils()
 tests = sorted(testUtils.getTests())
@@ -18,8 +13,13 @@ featureClass = None
 featureClasses = getFeatureClasses()
 
 
+def pytest_generate_tests(metafunc):
+  metafunc.parametrize(["testCase", "featureName"], metafunc.cls.generate_scenarios())
+
+
 class TestFeatures:
 
+  @staticmethod
   def generate_scenarios():
     global tests, featureClasses
 
@@ -51,17 +51,16 @@ class TestFeatures:
         for featureName in baselineFeatureNames:
           yield test, featureName
 
-  @parameterized.expand(generate_scenarios(), testcase_func_name=custom_name_func)
-  def test_scenario(self, test, featureName):
+  def test_scenario(self, testCase, featureName):
     print("")
     global testUtils, featureClass, featureClasses
 
     featureName = featureName.split('_')
 
-    logging.debug('test_scenario: test = %s, featureClassName = %s, featureName = %s', test, featureName[1],
+    logging.debug('test_scenario: test = %s, featureClassName = %s, featureName = %s', testCase, featureName[1],
                   featureName[-1])
 
-    testOrClassChanged = testUtils.setFeatureClassAndTestCase(featureName[1], test)
+    testOrClassChanged = testUtils.setFeatureClassAndTestCase(featureName[1], testCase)
 
     testImage = testUtils.getImage(featureName[0])
     testMask = testUtils.getMask(featureName[0])

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -1,16 +1,11 @@
-# to run this test, from directory above:
-# setenv PYTHONPATH /path/to/pyradiomics/radiomics
-# nosetests --nocapture -v tests/test_features.py
-
 import logging
 import os
 
-from nose_parameterized import parameterized
 import numpy
 import six
 
 from radiomics import getFeatureClasses, testCases
-from testUtils import custom_name_func, RadiomicsTestUtils
+from testUtils import RadiomicsTestUtils
 
 
 testUtils = RadiomicsTestUtils()
@@ -18,8 +13,13 @@ testUtils = RadiomicsTestUtils()
 featureClasses = getFeatureClasses()
 
 
+def pytest_generate_tests(metafunc):
+  metafunc.parametrize(["testCase", "featureClassName"], metafunc.cls.generate_scenarios())
+
+
 class TestMatrices:
 
+  @staticmethod
   def generate_scenarios():
     global featureClasses
 
@@ -32,18 +32,17 @@ class TestMatrices:
           logging.debug('generate_scenarios: featureClass = %s', className)
           yield testCase, className
 
-  @parameterized.expand(generate_scenarios(), testcase_func_name=custom_name_func)
-  def test_scenario(self, test, featureClassName):
+  def test_scenario(self, testCase, featureClassName):
     global testUtils, featureClasses
 
-    logging.debug('test_scenario: testCase = %s, featureClassName = %s', test, featureClassName)
+    logging.debug('test_scenario: testCase = %s, featureClassName = %s', testCase, featureClassName)
 
-    baselineFile = os.path.join(testUtils.getDataDir(), 'baseline', '%s_%s.npy' % (test, featureClassName))
+    baselineFile = os.path.join(testUtils.getDataDir(), 'baseline', '%s_%s.npy' % (testCase, featureClassName))
     assert os.path.isfile(baselineFile)
 
     baselineMatrix = numpy.load(baselineFile)
 
-    testUtils.setFeatureClassAndTestCase(featureClassName, test)
+    testUtils.setFeatureClassAndTestCase(featureClassName, testCase)
 
     testImage = testUtils.getImage('original')
     testMask = testUtils.getMask('original')


### PR DESCRIPTION
- MacOs build support was added to CircleCI, and free plans are no longer available on TravisCI. Therefore move the MacOs build to CircleCI
- Add Python 3.8 and 3.9 support
- Switch to use of pytest instead of nose (deprecated)
- Fix bug in selecting the label_channel based on input csv in batchprocessing
- Force label and label_channel to int for compatibility with SimpleITK