### PR TITLE
CI: Add MacOS Conda deployment step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,43 @@ jobs:
           command: |
             anaconda -t $ANACONDA_TOKEN upload -u Radiomics /conda-bld/linux-64/pyradiomics-*.tar.bz2 --force
 
+  deploy_conda_macos:
+    working_directory: ~/pyradiomics
+    macos:
+      xcode: 12.5.1
+    steps:
+      - run:
+          name: Setup MAC OS environment
+          # Workaround the following error occurring because python installation is cached but gettext dependency is not
+          #   dyld: Library not loaded: /usr/local/opt/gettext/lib/libintl.8.dylib
+          #     Referenced from: /Users/travis/.pyenv/versions/3.7.2/bin/python
+          #     Reason: Incompatible library version: python requires version 11.0.0 or later, but libintl.8.dylib provides version 10.0.0
+          # See https://github.com/scikit-build/cmake-python-distributions/issues/112 and
+          # https://github.com/scikit-build/cmake-python-distributions/pull/113
+          command: |
+            echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
+            brew install gettext
+            brew install pyenv
+            pyenv install miniconda3-latest
+            echo 'export PATH=$HOME/.pyenv/versions/miniconda3-latest/bin:$PATH' >> $BASH_ENV
+      - run:
+          name: Configure Miniconda
+          command: |
+            conda install gcc_linux-64 libgcc
+            bash ./conda/configure_conda.sh
+      - run:
+          name: Build Conda packages
+          command: |
+            mkdir  ~/conda-bld
+            conda build ./conda --python=3.6 --croot ~/conda-bld
+            conda build ./conda --python=3.7 --croot ~/conda-bld
+            conda build ./conda --python=3.8 --croot ~/conda-bld
+            conda build ./conda --python=3.9 --croot ~/conda-bld
+      - run:
+          name: Deploy Conda packages
+          command: |
+            anaconda -t $ANACONDA_TOKEN upload -u Radiomics ~/conda-bld/osx-64/pyradiomics-*.tar.bz2 --force
+
 workflows:
   version: 2
   build_and_deploy:
@@ -303,7 +340,7 @@ workflows:
             tags:
               only:
                 - /^v?[0-9]+(\.[0-9]+)*/
-      - deploy_conda:
+      - deploy_conda:  &deploy_conda_template
           <<: *requires_template
           filters:
             branches:
@@ -312,3 +349,6 @@ workflows:
             tags:
               only:
                 - /^v?[0-9]+(\.[0-9]+)*((a|b|rc)[0-9]+)?/
+
+      - deploy_conda_macos:
+          <<: *deploy_conda_template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,6 @@ jobs:
       - run:
           name: Configure Miniconda
           command: |
-            conda install gcc_linux-64 libgcc
             bash ./conda/configure_conda.sh
       - run:
           name: Build Conda packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,7 @@ jobs:
             brew install pyenv
             pyenv install miniconda3-latest
             echo 'export PATH=$HOME/.pyenv/versions/miniconda3-latest/bin:$PATH' >> $BASH_ENV
+      - checkout
       - run:
           name: Configure Miniconda
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,13 @@ jobs:
           command: |
             jupyter nbconvert --ExecutePreprocessor.kernel_name=python3 --ExecutePreprocessor.timeout=-1 --to notebook --output-dir /tmp --execute  notebooks/helloRadiomics.ipynb notebooks/helloFeatureClass.ipynb notebooks/PyRadiomicsExample.ipynb
 
-  build-mac-37: &build_mac_template
+  build-mac-38: &build_mac_template
     working_directory: ~/pyradiomics
     macos:
-      xcode: 12.5.1
+      xcode: 15.3.0
     environment:
-      PYTHON_VERSION: 3.7.10
-      PYTHON_SHORT_VERSION: 3.7
+      PYTHON_VERSION: 3.8.10
+      PYTHON_SHORT_VERSION: 3.8
     steps:
       - run:
           name: Setup MAC OS environment
@@ -82,22 +82,21 @@ jobs:
           root: .
           paths: [dist]
 
-  build-mac-38:
-    <<: *build_mac_template
-    environment:
-      PYTHON_VERSION: 3.8.10
-      PYTHON_SHORT_VERSION: 3.7
-
   build-mac-39:
     <<: *build_mac_template
     environment:
       PYTHON_VERSION: 3.9.5
       PYTHON_SHORT_VERSION: 3.9
 
-  build-37: &build_template
-    working_directory: /pyradiomics
+  build-mac-310:
+    <<: *build_mac_template
+    environment:
+      PYTHON_VERSION: 3.10.12
+      PYTHON_SHORT_VERSION: 3.10
+
+  build-38: &build_template
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
         user: root
     steps:
       - checkout
@@ -121,22 +120,22 @@ jobs:
           root: .
           paths: [dist]
 
-  build-38:
-    <<: *build_template
-    docker:
-      - image: cimg/python:3.8
-        user: root
-
   build-39:
     <<: *build_template
     docker:
       - image: cimg/python:3.9
         user: root
 
+  build-310:
+    <<: *build_template
+    docker:
+      - image: cimg/python:3.10
+        user: root
+
   test_deploy:
     working_directory: /pyradiomics
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
         user: root
     steps:
       - run:
@@ -181,7 +180,7 @@ jobs:
   deploy:
     working_directory: /pyradiomics
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.9
         user: root
     steps:
       - run:
@@ -249,10 +248,9 @@ jobs:
           name: Build Conda packages
           command: |
             mkdir  /conda-bld
-            conda build ./conda --python=3.6 --croot /conda-bld
-            conda build ./conda --python=3.7 --croot /conda-bld
             conda build ./conda --python=3.8 --croot /conda-bld
             conda build ./conda --python=3.9 --croot /conda-bld
+            conda build ./conda --python=3.10 --croot /conda-bld
       - run:
           name: Deploy Conda packages
           command: |
@@ -286,10 +284,9 @@ jobs:
           name: Build Conda packages
           command: |
             mkdir  ~/conda-bld
-            conda build ./conda --python=3.6 --croot ~/conda-bld
-            conda build ./conda --python=3.7 --croot ~/conda-bld
             conda build ./conda --python=3.8 --croot ~/conda-bld
             conda build ./conda --python=3.9 --croot ~/conda-bld
+            conda build ./conda --python=3.10 --croot ~/conda-bld
       - run:
           name: Deploy Conda packages
           command: |
@@ -299,29 +296,29 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build-mac-37: &build_job_template
+      - build-mac-38: &build_job_template
           filters:
             tags:
               only:
                 - /^v?[0-9]+(\.[0-9]+)*((a|b|rc)[0-9]+)?/
-      - build-mac-38:
-          <<: *build_job_template
       - build-mac-39:
           <<: *build_job_template
-      - build-37:
+      - build-mac-310:
           <<: *build_job_template
       - build-38:
           <<: *build_job_template
       - build-39:
           <<: *build_job_template
+      - build-310:
+          <<: *build_job_template
       - test-notebooks: &requires_template
           requires:
-            - build-37
             - build-38
             - build-39
-            - build-mac-37
+            - build-310
             - build-mac-38
             - build-mac-39
+            - build-mac-310
       - test_deploy:
           <<: *requires_template
           filters:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
 
     # Visual Studio (Python 3, 64 bit)
 
-    - PYTHON_DIR: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
-      PYTHON_SHORT_VERSION: "3.7"
-
     - PYTHON_DIR: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.x"
       PYTHON_SHORT_VERSION: "3.8"
@@ -20,6 +16,11 @@ environment:
     - PYTHON_DIR: "C:\\Python39-x64"
       PYTHON_VERSION: "3.9.x"
       PYTHON_SHORT_VERSION: "3.9"
+
+    - PYTHON_DIR: "C:\\Python310-x64"
+      PYTHON_VERSION: "3.10.x"
+      PYTHON_SHORT_VERSION: "3.10"
+
 
 init:
   - ps: $env:PATH=$env:PYTHON_DIR + ";" + $env:PYTHON_DIR + "\\Scripts;" + $env:PATH


### PR DESCRIPTION
Recently, CI for MacOs was moved to CircleCI. Wheels intended for PyPi distribution are build as part of the general testing, including wheels for MacOS. However, conda deployment is handled in a separate step, which in CircleCI currently only handles distribution of Linux Packages. Therefore, add a conda-deployment step to generate and upload pyradiomics packages for conda on MacOS.