### PR TITLE
Make the package poetry friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # pyradiomics v3.1.0
 
+This is a fork of the `pyradiomics` original package. It seems that the package is not properly maintained since early 
+2022, and it especially causes issues with the distribution through poetry as the build is not properly handled for 
+python>3.6. The goal of this fork is to circumvent this issue and others that may arise until the main package gets 
+a proper release.
+
+In order to add this version of `pyradiomics` to a project, run
+
+    poetry add git+https://github.com/owkin/pyradiomics
+
+Below is the original README.
+
 ## Build Status
 
 | Linux / MacOS                 | Windows                       |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [build-system]
-requires = ["setuptools>=61.0", "numpy", "versioneer"]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61.0", "numpy", "versioneer", "poetry-core>=1.0.0"]
+build-backend = ["poetry.core.masonry.api", "setuptools.build_meta"]
 
-[project]
+[tool.poetry]
 name = "pyradiomics"
-version = "3.0.1a1"
-authors = [
-    { name = "PyRadimiomics Community", email = "pyradiomics@googlegroups.com"}
+packages = [
+    {include = "radiomics"}
 ]
+version = "3.0.1a1"
+authors = ["PyRadimiomics Community",  "pyradiomics@googlegroups.com"]
 description = "Radiomics features library for python"
 readme = "README.md"
-requires-python =">=3.5"
-license = { file = "LICENSE.txt"}
+license = "LICENSE.txt"
 keywords = [ "radiomics", "cancerimaging", "medicalresearch", "computationalimaging" ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -26,22 +26,19 @@ classifiers = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering :: Bio-Informatics'
 ]
-dependencies = [
-    "numpy",
-    "SimpleITK",
-    "PyWavelets",
-    "pykwalify",
-    "six"
-]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+numpy = "^1.21.2"
+SimpleITK = "^2.1.1"
+PyWavelets = "^1.1.1"
+pykwalify = "^1.8.0"
+six = "^1.16.0"
 
 [project.scripts]
 pyradiomics = "radiomics.scripts.__init__:parse_args"
 
-[project.urls]
-"Homepaget" = "http://github.com/AIM-Harvard/pyradiomics#readme"
-"Radiomics.io" = "https://www.radiomics.io/"
-"Documentation" = "https://pyradiomics.readthedocs.io/en/latest/index.html"
-"Docker" = "https://hub.docker.com/r/radiomics/pyradiomics/"
-"Github" = "https://github.com/AIM-Harvard/pyradiomics"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=61.0", "numpy", "versioneer", "poetry-core>=1.0.0"]
-build-backend = ["poetry.core.masonry.api", "setuptools.build_meta"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyradiomics"


### PR DESCRIPTION
## PR description

This PR switches the `build-backend` from `setuptools` to `poetry.masonry.api`. This way, the package can be built in accordance with PEP517 and PEP518 standards when added to other packages' requirements, using poetry.