### PR TITLE
SafeLoadRemove Error in Slicer

### DIFF
--- a/radiomics/scripts/__init__.py
+++ b/radiomics/scripts/__init__.py
@@ -19,6 +19,7 @@ import radiomics
 import radiomics.featureextractor
 from . import segment, voxel
 
+from ruamel.yaml import YAML
 
 class PyRadiomicsCommandLine:
 
@@ -350,7 +351,8 @@ class PyRadiomicsCommandLine:
     self.logger.debug('Reading parameter schema')
     schemaFile, schemaFuncs = radiomics.getParameterValidationFiles()
     with open(schemaFile) as schema:
-      settingsSchema = yaml.safe_load(schema)['mapping']['setting']['mapping']
+      yaml = YAML(typ='safe', pure=True)
+      settingsSchema = yaml.load(schema)['mapping']['setting']['mapping']
 
     # parse single value function
     def parse_value(value, value_type):


### PR DESCRIPTION
I recently found the SlicerRadiomics extension does not work in 3D Slicer and below is the issue that I decribed in.
https://github.com/AIM-Harvard/SlicerRadiomics/issues/80

I tried to modify the code with the help of @pieper :
1. Add the code below to the top of the file:
`from ruamel.yaml import YAML`
2. Add the code below before line 353:
`yaml = YAML(typ='safe', pure=True) `
3. Change what was in line 353 to:
`settingsSchema = yaml.load(schema)['mapping']['setting']['mapping']`