### PR TITLE
fix typo in gldm sde formula

### DIFF
--- a/radiomics/gldm.py
+++ b/radiomics/gldm.py
@@ -133,7 +133,7 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     **1. Small Dependence Emphasis (SDE)**
 
     .. math::
-      SDE = \frac{\sum^{N_g}_{i=1}\sum^{N_d}_{j=1}{\frac{\textbf{P}(i,j)}{i^2}}}{N_z}
+      SDE = \frac{\sum^{N_g}_{i=1}\sum^{N_d}_{j=1}{\frac{\textbf{P}(i,j)}{j^2}}}{N_z}
 
     A measure of the distribution of small dependencies, with a greater value indicative
     of smaller dependence and less homogeneous textures.


### PR DESCRIPTION
Fixed the formula for SDE calculation from GLDM. The present formula is actually for LGLE.
I also checked the formula against [IBSI documentation](https://arxiv.org/pdf/1612.07003) (Chapter 3.11.1).