### PR TITLE
Update functionality in `versioneer.py` and `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils import sysconfig
+import sysconfig
 import platform
 
 import numpy
@@ -8,10 +8,10 @@ from setuptools import Extension, setup
 import versioneer
 
 if platform.architecture()[0].startswith('32'):
-  raise Exception('PyRadiomics requires 64 bits python')
+    raise Exception('PyRadiomics requires 64 bits python')
 
 commands = versioneer.get_cmdclass()
-incDirs = [sysconfig.get_python_inc(), numpy.get_include()]
+incDirs = [sysconfig.get_paths()['include'], numpy.get_include()]
 
 ext = [Extension("radiomics._cmatrices", ["radiomics/src/_cmatrices.c", "radiomics/src/cmatrices.c"],
                  include_dirs=incDirs),

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
So, I've been using radiomics in an image segmentation project and had to install it from source. I made two key changes:

### 1. **`versioneer.py` file**
<details>
<summary><b>Update for `SafeConfigParser` Deprecation</b></summary>

In the `versioneer.py` file, I updated the use of `SafeConfigParser`. The `SafeConfigParser` class has been renamed to [`ConfigParser`](https://github.com/python/cpython/blob/b1d6f8a2ee04215c64aa8752cc515b7e98a08d28/Lib/configparser.py#L1243). From Python 3.2 and above, `ConfigParser` should be used directly.

```python
/usr/lib/python3.9/site-packages/nitrate/config.py:273: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
parser = ConfigParser.SafeConfigParser()

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
</details> 

<details>
<summary><b>Update for `readfp` Deprecation</b></summary>

The `readfp` method has been removed in future versions. It now supports the [`parser.read_file()`](https://github.com/python/cpython/blob/b1d6f8a2ee04215c64aa8752cc515b7e98a08d28/Lib/configparser.py#L755) method.

```python
telemetryconfig.py:46: DeprecationWarning: This method will be removed in future versions. Use 'parser.read_file()' instead.
  self.config_parser.readfp(f)
```
</details> 

### 2. `setup.py` file

1. Updated the import statement to use `import sysconfig`.
2. Fixed the if statement condition.
3. Updated the include directories retrieval to reflect changes in the `sysconfig` API.
