### PR TITLE
ENH: Refactor code to remove `six` usage in iteration syntax.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -830,11 +830,6 @@ Bug fixes
 - Fix datatype error when calling ``SimpleITK.ResampleImageFilter.SetSize()`` (only causes error in python 3,
   `#205 <https://github.com/AIM-Harvard/pyradiomics/pull/205>`_)
 
-Requirements
-############
-
-- Add requirement for ``six>=1.10.0``, needed to make PyRadiomics compatible with both python 2 and 3.
-
 Documentation
 #############
 
@@ -865,8 +860,7 @@ Internal API
   feature classes and filters at initialization of the toolbox, and ensures feature classes are imported at
   initialization. (`#190 <https://github.com/AIM-Harvard/pyradiomics/pull/190>`_,
   `#198 <https://github.com/AIM-Harvard/pyradiomics/pull/198>`_)
-- Python 3 Compatibility. Add support for compatibility with python 2.7 and python >= 3.4. This is achieved using
-  package ``six``.
+- Python 3 Compatibility is required
 - Standardize function names for calculating matrices in python and with C extensions to ``_calculateMatrix`` and
   ``_calculateCMatrix``, respectively.
 - Make C code consistent with C89 convention. All variables (pointers for python objects) are initialized at top of each

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ available [here](https://github.com/AIM-Harvard/SlicerRadiomics).
 - numpy (Feature calculation)
 - PyWavelets (Wavelet filter)
 - pykwalify (Enabling yaml parameters file checking)
-- six (Python 3 Compatibility)
 - scipy (Only for LBP filter, install separately to enable this filter)
 - scikit-image (Only for LBP filter, install separately to enable this filter)
 - trimesh (Only for LBP filter, install separately to enable this filter)

--- a/bin/DatasetHierarchyReader.py
+++ b/bin/DatasetHierarchyReader.py
@@ -5,8 +5,6 @@ import collections
 import glob
 import os
 
-import six
-
 
 class DatasetHierarchyReader(object):
   def __init__(self, inputDatasetDirectory, filetype='.nrrd'):
@@ -105,7 +103,7 @@ class DatasetHierarchyReader(object):
     """
 
     keywordSettings = {k: [str(keyword.strip()) for keyword in v.split(',')]
-                       for (k, v) in six.iteritems(keywordSettings)}
+                       for (k, v) in keywordSettings.items()}
 
     matchedImages = []
     for imageFilepath in imageFilepaths:

--- a/bin/GenerateInputCSV_Filename.py
+++ b/bin/GenerateInputCSV_Filename.py
@@ -3,8 +3,6 @@ from __future__ import print_function
 import csv
 import os
 
-import six
-
 SqDic = {}
 SqDic['T2-TSE-TRA'] = 't2tra'
 SqDic['T2-TRA'] = 't2tra'
@@ -43,16 +41,16 @@ def main():
   print("Found %s patients, writing csv" % (len(datasetHierarchyDict.keys())))
 
   try:
-    with open(outputFile, 'wb') as outFile:
+    with open(outputFile, 'w') as outFile:
       cw = csv.writer(outFile, lineterminator='\n')
       cw.writerow(['Patient', 'Sequence', 'Reader', 'Image', 'Mask'])
 
-      for patient, Studies in sorted(six.iteritems(datasetHierarchyDict), key=lambda t: t[0]):
-        for Study, im_fileList in sorted(six.iteritems(Studies['reconstructions']), key=lambda t: t[0]):
+      for patient, Studies in sorted(datasetHierarchyDict.items(), key=lambda t: t[0]):
+        for Study, im_fileList in sorted(Studies['reconstructions'].items(), key=lambda t: t[0]):
           for i_idx, im_file in enumerate(im_fileList):
 
-            if Studies['segmentations'].has_key(Study):
-              for Reader, seg_fileList in sorted(six.iteritems(Studies['segmentations'][Study]), key=lambda t: t[0]):
+            if Study in Studies['segmentations']:
+              for Reader, seg_fileList in sorted(Studies['segmentations'][Study].items(), key=lambda t: t[0]):
                 for s_idx, seg_file in enumerate(sorted(seg_fileList)):
 
                   i_name = Study
@@ -75,22 +73,22 @@ def scanpatients(f, filetype):
       if (fname[0:3] == "Pt-") & (fname.endswith(filetype)):
         PtNo = fname[3:7]
 
-        if not outputDict.has_key(PtNo):
+        if PtNo not in outputDict:
           outputDict[PtNo] = {'reconstructions': {}}
           outputDict[PtNo]['segmentations'] = {}
 
-        for SqKey, SqVal in six.iteritems(SqDic):
+        for SqKey, SqVal in SqDic.items():
           if ("ROI_" + SqVal) in fname:
-            for ReaderKey, ReaderVal in six.iteritems(LabelDic):
+            for ReaderKey, ReaderVal in LabelDic.items():
               if (ReaderKey + '_') in fname:
-                if not outputDict[PtNo]['segmentations'].has_key(SqVal):
+                if SqVal not in outputDict[PtNo]['segmentations']:
                   outputDict[PtNo]['segmentations'][SqVal] = {}
-                if not outputDict[PtNo]['segmentations'][SqVal].has_key(ReaderVal):
+                if ReaderVal not in outputDict[PtNo]['segmentations'][SqVal]:
                   outputDict[PtNo]['segmentations'][SqVal][ReaderVal] = set()
                 outputDict[PtNo]['segmentations'][SqVal][ReaderVal].add(os.path.join(dirpath, fname))
                 break
           elif SqKey in fname:
-            if not outputDict[PtNo]['reconstructions'].has_key(SqVal):
+            if SqVal not in outputDict[PtNo]['reconstructions']:
               outputDict[PtNo]['reconstructions'][SqVal] = set()
             outputDict[PtNo]['reconstructions'][SqVal].add(os.path.join(dirpath, fname))
             break

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,14 +22,12 @@ requirements:
     - pykwalify >=1.6.0
     - pywavelets >=0.4.0
     - SimpleITK !=1.1.0
-    - six >=1.10.0
   run:
     - python
     - numpy >=1.9.2
     - pykwalify >=1.6.0
     - pywavelets >=0.4.0
     - SimpleITK !=1.1.0
-    - six >=1.10.0
     - scipy
     - scikit-learn
     - trimesh

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -184,7 +184,6 @@ Using feature classes directly
 
      from radiomics import firstorder, glcm, imageoperations, shape, glrlm, glszm, getTestCase
      import SimpleITK as sitk
-     import six
      import sys, os
 
 * Set up a data directory variable::
@@ -204,7 +203,7 @@ Using feature classes directly
      firstOrderFeatures = firstorder.RadiomicsFirstOrder(image,mask)
      firstOrderFeatures.enableAllFeatures()  # On the feature class level, all features are disabled by default.
      firstOrderFeatures.calculateFeatures()
-     for (key,val) in six.iteritems(firstOrderFeatures.featureValues):
+     for (key,val) in firstOrderFeatures.featureValues.items():
        print("\t%s: %s" % (key, val))
 
 * See the :ref:`radiomics-features-label` section for more features that you can calculate.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,7 +107,6 @@ and filters, thereby enabling fully reproducible feature extraction. For more in
 * numpy (Feature calculation)
 * PyWavelets (Wavelet filter)
 * pykwalify (Enabling yaml parameters file checking)
-* six (Python 3 Compatibility)
 
 See also the `requirements file <https://github.com/Radiomics/pyradiomics/blob/master/requirements.txt>`_.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -127,7 +127,6 @@ Interactive Use
      import os
 
      import SimpleITK as sitk
-     import six
 
      from radiomics import featureextractor, getTestCase
 
@@ -152,13 +151,13 @@ Interactive Use
 * Calculate the features (segment-based)::
 
     result = extractor.execute(imageName, maskName)
-    for key, val in six.iteritems(result):
+    for key, val in result.items():
       print("\t%s: %s" %(key, val))
 
 * Calculate the features (voxel-based)::
 
     result = extractor.execute(imageName, maskName, voxelBased=True)
-    for key, val in six.iteritems(result):
+    for key, val in result.items():
       if isinstance(val, sitk.Image):  # Feature map
         sitk.WriteImage(val, key + '.nrrd', True)
         print("Stored feature %s in %s" % (key, key + ".nrrd"))

--- a/examples/helloFeatureClass.py
+++ b/examples/helloFeatureClass.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 import numpy
 import SimpleITK as sitk
-import six
 
 from radiomics import firstorder, getTestCase, glcm, glrlm, glszm, imageoperations, shape
 
@@ -65,7 +64,7 @@ results = firstOrderFeatures.execute()
 print('done')
 
 print('Calculated first order features: ')
-for (key, val) in six.iteritems(results):
+for (key, val) in results.items():
   print('  ', key, ':', val)
 
 #
@@ -84,7 +83,7 @@ results = shapeFeatures.execute()
 print('done')
 
 print('Calculated Shape features: ')
-for (key, val) in six.iteritems(results):
+for (key, val) in results.items():
   print('  ', key, ':', val)
 
 #
@@ -103,7 +102,7 @@ results = glcmFeatures.execute()
 print('done')
 
 print('Calculated GLCM features: ')
-for (key, val) in six.iteritems(results):
+for (key, val) in results.items():
   print('  ', key, ':', val)
 
 #
@@ -122,7 +121,7 @@ results = glrlmFeatures.execute()
 print('done')
 
 print('Calculated GLRLM features: ')
-for (key, val) in six.iteritems(results):
+for (key, val) in results.items():
   print('  ', key, ':', val)
 
 #
@@ -141,7 +140,7 @@ results = glszmFeatures.execute()
 print('done')
 
 print('Calculated GLSZM features: ')
-for (key, val) in six.iteritems(results):
+for (key, val) in results.items():
   print('  ', key, ':', val)
 
 #
@@ -153,7 +152,7 @@ if applyLog:
     logFirstorderFeatures = firstorder.RadiomicsFirstOrder(logImage, mask, **inputKwargs)
     logFirstorderFeatures.enableAllFeatures()
     results = logFirstorderFeatures.execute()
-    for (key, val) in six.iteritems(results):
+    for (key, val) in results.items():
       laplacianFeatureName = '%s_%s' % (imageTypeName, key)
       print('  ', laplacianFeatureName, ':', val)
 #
@@ -165,6 +164,6 @@ if applyWavelet:
     waveletFirstOrderFeaturs.enableAllFeatures()
     results = waveletFirstOrderFeaturs.execute()
     print('Calculated firstorder features with wavelet ', decompositionName)
-    for (key, val) in six.iteritems(results):
+    for (key, val) in results.items():
       waveletFeatureName = '%s_%s' % (str(decompositionName), key)
       print('  ', waveletFeatureName, ':', val)

--- a/examples/helloRadiomicsWithSettings.py
+++ b/examples/helloRadiomicsWithSettings.py
@@ -5,8 +5,6 @@ from __future__ import print_function
 import logging
 import os
 
-import six
-
 import radiomics
 from radiomics import featureextractor, getFeatureClasses
 
@@ -41,9 +39,9 @@ extractor = featureextractor.RadiomicsFeatureExtractor(paramsFile)
 featureClasses = getFeatureClasses()
 
 print("Active features:")
-for cls, features in six.iteritems(extractor.enabledFeatures):
+for cls, features in extractor.enabledFeatures.items():
   if features is None or len(features) == 0:
-    features = [f for f, deprecated in six.iteritems(featureClasses[cls].getFeatureNames()) if not deprecated]
+    features = [f for f, deprecated in featureClasses[cls].getFeatureNames().items() if not deprecated]
   for f in features:
     print(f)
     print(getattr(featureClasses[cls], 'get%sFeatureValue' % f).__doc__)

--- a/examples/helloVoxel.py
+++ b/examples/helloVoxel.py
@@ -6,7 +6,6 @@ import logging
 import os
 
 import SimpleITK as sitk
-import six
 
 import radiomics
 from radiomics import featureextractor, getFeatureClasses
@@ -106,9 +105,9 @@ tqdmProgressbar()
 # clickProgressbar()
 
 print("Active features:")
-for cls, features in six.iteritems(extractor.enabledFeatures):
+for cls, features in extractor.enabledFeatures.items():
   if features is None or len(features) == 0:
-    features = [f for f, deprecated in six.iteritems(featureClasses[cls].getFeatureNames()) if not deprecated]
+    features = [f for f, deprecated in featureClasses[cls].getFeatureNames().items() if not deprecated]
   for f in features:
     print(f)
     print(getattr(featureClasses[cls], 'get%sFeatureValue' % f).__doc__)
@@ -116,7 +115,7 @@ for cls, features in six.iteritems(extractor.enabledFeatures):
 print("Calculating features")
 featureVector = extractor.execute(imageName, maskName, voxelBased=True)
 
-for featureName, featureValue in six.iteritems(featureVector):
+for featureName, featureValue in featureVector.items():
   if isinstance(featureValue, sitk.Image):
     sitk.WriteImage(featureValue, '%s_%s.nrrd' % (testCase, featureName))
     print('Computed %s, stored as "%s_%s.nrrd"' % (featureName, testCase, featureName))

--- a/notebooks/FeatureVisualization.ipynb
+++ b/notebooks/FeatureVisualization.ipynb
@@ -46,7 +46,7 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "\n",
-    "from six.moves import urllib\n",
+    "import urllib.request\n",
     "\n",
     "url = \"http://www.spl.harvard.edu/publications/bitstream/download/5270\"\n",
     "filename = 'example_data/Tumorbase.zip'\n",
@@ -57,7 +57,7 @@
     "    urllib.request.urlretrieve(url, filename)\n",
     "else:\n",
     "    print (\"file already downloaded\")\n",
-    "    \n",
+    "\n",
     "extracted_path = 'example_data/tumorbase'\n",
     "if not os.path.isdir(extracted_path):\n",
     "    print (\"unzipping\")\n",
@@ -116,7 +116,7 @@
     "    mask = sitk.ReadImage(path + \"segmented.nrrd\")\n",
     "    # Tumor is in label value 6\n",
     "    features[case_id] = extractor.execute ( image, mask, label=6 )\n",
-    "    \n",
+    "\n",
     "\n",
     "# A list of the valid features, sorted\n",
     "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), features[1] )))"
@@ -141,7 +141,7 @@
     "    for feature_name in feature_names:\n",
     "        a = np.append(a, features[case_id][feature_name])\n",
     "    samples[case_id-1,:] = a\n",
-    "    \n",
+    "\n",
     "# May have NaNs\n",
     "samples = np.nan_to_num(samples)"
    ]
@@ -344,7 +344,7 @@
     "pp = sns.clustermap(dd.corr(), linewidths=.5, figsize=(13,13))\n",
     "_ = plt.setp(pp.ax_heatmap.get_yticklabels(), rotation=0)\n",
     "\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   }
  ],

--- a/notebooks/FeatureVisualizationWithClustering.ipynb
+++ b/notebooks/FeatureVisualizationWithClustering.ipynb
@@ -46,7 +46,7 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "\n",
-    "from six.moves import urllib\n",
+    "import urllib.request\n",
     "\n",
     "url = \"http://www.spl.harvard.edu/publications/bitstream/download/5270\"\n",
     "filename = 'example_data/Tumorbase.zip'\n",
@@ -57,7 +57,7 @@
     "    urllib.request.urlretrieve(url, filename)\n",
     "else:\n",
     "    print (\"file already downloaded\")\n",
-    "    \n",
+    "\n",
     "extracted_path = 'example_data/tumorbase'\n",
     "if not os.path.isdir(extracted_path):\n",
     "    print (\"unzipping\")\n",
@@ -116,7 +116,7 @@
     "    mask = sitk.ReadImage(path + \"segmented.nrrd\")\n",
     "    # Tumor is in label value 6\n",
     "    features[case_id] = extractor.execute ( image, mask, label=6 )\n",
-    "    \n",
+    "\n",
     "\n",
     "# A list of the valid features, sorted\n",
     "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), features[1] )))"
@@ -141,7 +141,7 @@
     "    for feature_name in feature_names:\n",
     "        a = np.append(a, features[case_id][feature_name])\n",
     "    samples[case_id-1,:] = a\n",
-    "    \n",
+    "\n",
     "# May have NaNs\n",
     "samples = np.nan_to_num(samples)"
    ]
@@ -685,7 +685,7 @@
    "source": [
     "pp = sns.clustermap(d, col_cluster=False, metric='chebyshev', z_score=1)\n",
     "_ = plt.setp(pp.ax_heatmap.get_yticklabels(), rotation=0)\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   }
  ],

--- a/notebooks/FilteringEffects.ipynb
+++ b/notebooks/FilteringEffects.ipynb
@@ -33,7 +33,7 @@
     "# Radiomics package\n",
     "from radiomics import featureextractor\n",
     "\n",
-    "import six, numpy as np"
+    "import numpy as np"
    ]
   },
   {
@@ -208,7 +208,7 @@
     "\n",
     "results[\"baseline\"] = extractor.execute(image, label)\n",
     "\n",
-    "for key, value in six.iteritems(filters):\n",
+    "for key, value in filters.items():\n",
     "    print ( \"filtering with \" + key )\n",
     "    filtered_image = value.Execute(image)\n",
     "    results[key] = extractor.execute(filtered_image, label)"
@@ -305,7 +305,7 @@
     "        a = np.append(a, results[f][key])\n",
     "    features[key] = a\n",
     "    cv[key] = scipy.stats.variation(a)\n",
-    "    \n",
+    "\n",
     "# a sorted view of cv\n",
     "cv_sorted = sorted(cv, key=cv.get, reverse=True)\n",
     "\n",
@@ -314,11 +314,11 @@
     "print (\"Top 10 features with largest coefficient of variation\")\n",
     "for i in range(0,10):\n",
     "    print (\"Feature: {:<50} CV: {}\".format ( cv_sorted[i], cv[cv_sorted[i]]))\n",
-    "    \n",
+    "\n",
     "print (\"\\n\")\n",
     "print (\"Bottom 10 features with _smallest_ coefficient of variation\")\n",
     "for i in range(-11,-1):\n",
-    "    print (\"Feature: {:<50} CV: {}\".format ( cv_sorted[i], cv[cv_sorted[i]]))"
+    "    print (\"Feature: {:<50} CV: {}\".format ( cv_sorted[i], cv[cv_sorted[i]]))\n"
    ]
   }
  ],

--- a/notebooks/PyRadiomicsExample.ipynb
+++ b/notebooks/PyRadiomicsExample.ipynb
@@ -24,7 +24,6 @@
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
-    "import six\n",
     "import os  # needed navigate the system to get the input data\n",
     "\n",
     "import radiomics\n",
@@ -451,7 +450,7 @@
     "print('Result type:', type(result))  # result is returned in a Python ordered dictionary)\n",
     "print('')\n",
     "print('Calculated features')\n",
-    "for key, value in six.iteritems(result):\n",
+    "for key, value in result.items():\n",
     "    print('\\t', key, ':', value)"
    ]
   }

--- a/notebooks/RadiomicsExample.ipynb
+++ b/notebooks/RadiomicsExample.ipynb
@@ -35,7 +35,7 @@
     "# Radiomics package\n",
     "from radiomics import featureextractor\n",
     "\n",
-    "import six, numpy as np"
+    "import numpy as np"
    ]
   },
   {
@@ -189,7 +189,7 @@
     "feature_1 = np.array([])\n",
     "feature_2 = np.array([])\n",
     "\n",
-    "for key, value in six.iteritems(result_1):\n",
+    "for key, value in result_1.items():\n",
     "    if key.startswith(\"original_\"):\n",
     "        feature_1 = np.append ( feature_1, result_1[key])\n",
     "        feature_2 = np.append ( feature_2, result_2[key])"

--- a/notebooks/helloFeatureClass.ipynb
+++ b/notebooks/helloFeatureClass.ipynb
@@ -28,7 +28,6 @@
     "import collections\n",
     "import SimpleITK as sitk\n",
     "import numpy\n",
-    "import six\n",
     "import radiomics\n",
     "from radiomics import firstorder, glcm, imageoperations, shape, glrlm, glszm"
    ]
@@ -233,7 +232,7 @@
     "print('done')\n",
     "\n",
     "print('Calculated first order features: ')\n",
-    "for (key, val) in six.iteritems(result):\n",
+    "for (key, val) in result.items():\n",
     "  print('  ', key, ':', val)"
    ]
   },
@@ -506,7 +505,7 @@
     "print('done')\n",
     "\n",
     "print('Calculated shape features: ')\n",
-    "for (key, val) in six.iteritems(result):\n",
+    "for (key, val) in result.items():\n",
     "  print('  ', key, ':', val)"
    ]
   },
@@ -940,7 +939,7 @@
     "print('done')\n",
     "\n",
     "print('Calculated GLCM features: ')\n",
-    "for (key, val) in six.iteritems(result):\n",
+    "for (key, val) in result.items():\n",
     "  print('  ', key, ':', val)"
    ]
   },
@@ -1196,7 +1195,7 @@
     "print('done')\n",
     "\n",
     "print('Calculated GLRLM features: ')\n",
-    "for (key, val) in six.iteritems(result):\n",
+    "for (key, val) in result.items():\n",
     "  print('  ', key, ':', val)"
    ]
   },
@@ -1451,7 +1450,7 @@
     "print('done')\n",
     "\n",
     "print('Calculated GLSZM features: ')\n",
-    "for (key, val) in six.iteritems(result):\n",
+    "for (key, val) in result.items():\n",
     "  print('  ', key, ':', val)"
    ]
   },
@@ -1563,8 +1562,8 @@
    ],
    "source": [
     "# Show result\n",
-    "for sigma, features in six.iteritems(logFeatures):\n",
-    "  for (key, val) in six.iteritems(features):\n",
+    "for sigma, features in logFeatures.items():\n",
+    "  for (key, val) in features.items():\n",
     "    laplacianFeatureName = '%s_%s' % (str(sigma), key)\n",
     "    print('  ', laplacianFeatureName, ':', val)"
    ]
@@ -1776,8 +1775,8 @@
    ],
    "source": [
     "# Show result\n",
-    "for decompositionName, features in six.iteritems(waveletFeatures):\n",
-    "  for (key, val) in six.iteritems(features):\n",
+    "for decompositionName, features in waveletFeatures.items():\n",
+    "  for (key, val) in features.items():\n",
     "    waveletFeatureName = '%s_%s' % (str(decompositionName), key)\n",
     "    print('  ', waveletFeatureName, ':', val)"
    ]

--- a/notebooks/helloRadiomics.ipynb
+++ b/notebooks/helloRadiomics.ipynb
@@ -28,7 +28,6 @@
     "import sys\n",
     "import os\n",
     "import logging\n",
-    "import six\n",
     "from radiomics import featureextractor, getFeatureClasses\n",
     "import radiomics"
    ]
@@ -480,9 +479,9 @@
    ],
    "source": [
     "print('Active features:')\n",
-    "for cls, features in six.iteritems(extractor.enabledFeatures):\n",
+    "for cls, features in extractor.enabledFeatures.items():\n",
     "    if len(features) == 0:\n",
-    "        features = [f for f, deprecated in six.iteritems(featureClasses[cls].getFeatureNames()) if not deprecated]\n",
+    "        features = [f for f, deprecated in featureClasses[cls].getFeatureNames().items() if not deprecated]\n",
     "    for f in features:\n",
     "        print(f)\n",
     "        print(getattr(featureClasses[cls], 'get%sFeatureValue' % f).__doc__)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,9 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "numpy",
-    "SimpleITK ==2.3.1",
+    "SimpleITK ==2.4.1",
     "PyWavelets >= 1.6.0",
-    "pykwalify >= 1.6.0",
-    "six"
+    "pykwalify >= 1.6.0"
 ]
 
 [project.optional-dependencies]

--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 
 import numpy  # noqa: F401
-from six.moves import urllib
+import urllib.request
 
 from . import imageoperations
 

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -4,7 +4,6 @@ import traceback
 
 import numpy
 import SimpleITK as sitk
-import six
 
 from radiomics import getProgressReporter, imageoperations
 
@@ -139,7 +138,7 @@ class RadiomicsFeaturesBase(object):
       or in the parameter file (by specifying the feature by name, not when enabling all features).
       However, in most cases this will still result only in a deprecation warning.
     """
-    for featureName, is_deprecated in six.iteritems(self.featureNames):
+    for featureName, is_deprecated in self.featureNames.items():
       # only enable non-deprecated features here
       if not is_deprecated:
         self.enableFeatureByName(featureName, True)
@@ -191,7 +190,7 @@ class RadiomicsFeaturesBase(object):
     voxelBatch = self.settings.get('voxelBatch', -1)
 
     # Initialize the output with empty numpy arrays
-    for feature, enabled in six.iteritems(self.enabledFeatures):
+    for feature, enabled in self.enabledFeatures.items():
       if enabled:
         self.featureValues[feature] = numpy.full(list(self.inputImage.GetSize())[::-1], initValue, dtype='float')
 
@@ -214,7 +213,7 @@ class RadiomicsFeaturesBase(object):
         pbar.update(1)  # Update progress bar
 
     # Convert the output to simple ITK image objects
-    for feature, enabled in six.iteritems(self.enabledFeatures):
+    for feature, enabled in self.enabledFeatures.items():
       if enabled:
         self.featureValues[feature] = sitk.GetImageFromArray(self.featureValues[feature])
         self.featureValues[feature].CopyInformation(self.inputImage)
@@ -231,7 +230,7 @@ class RadiomicsFeaturesBase(object):
     self._initCalculation(voxelCoordinates)
 
     self.logger.debug('Calculating features')
-    for feature, enabled in six.iteritems(self.enabledFeatures):
+    for feature, enabled in self.enabledFeatures.items():
       if enabled:
         try:
           # Use getattr to get the feature calculation methods, then use '()' to evaluate those methods

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -10,7 +10,6 @@ import pathlib
 
 import pykwalify.core
 import SimpleITK as sitk
-import six
 
 from radiomics import generalinfo, getFeatureClasses, getImageTypes, getParameterValidationFiles, imageoperations
 
@@ -56,7 +55,7 @@ class RadiomicsFeatureExtractor:
     if len(args) == 1 and isinstance(args[0], dict):
       logger.info("Loading parameter dictionary")
       self._applyParams(paramsDict=args[0])
-    elif len(args) == 1 and (isinstance(args[0], six.string_types) or isinstance(args[0], pathlib.PurePath)):
+    elif len(args) == 1 and (isinstance(args[0], str) or isinstance(args[0], pathlib.PurePath)):
       if not os.path.isfile(args[0]):
         raise IOError("Parameter file %s does not exist." % args[0])
       logger.info("Loading parameter file %s", str(args[0]))
@@ -316,7 +315,7 @@ class RadiomicsFeatureExtractor:
     # Make generators for all enabled image types
     logger.debug('Creating image type iterator')
     imageGenerators = []
-    for imageType, customKwargs in six.iteritems(self.enabledImagetypes):
+    for imageType, customKwargs in self.enabledImagetypes.items():
       args = _settings.copy()
       args.update(customKwargs)
       logger.info('Adding image type "%s" with custom settings: %s' % (imageType, str(customKwargs)))
@@ -367,14 +366,14 @@ class RadiomicsFeatureExtractor:
     label = kwargs.get('label', 1)
 
     logger.info('Loading image and mask')
-    if isinstance(ImageFilePath, six.string_types) and os.path.isfile(ImageFilePath):
+    if isinstance(ImageFilePath, str) and os.path.isfile(ImageFilePath):
       image = sitk.ReadImage(ImageFilePath)
     elif isinstance(ImageFilePath, sitk.SimpleITK.Image):
       image = ImageFilePath
     else:
       raise ValueError('Error reading image Filepath or SimpleITK object')
 
-    if isinstance(MaskFilePath, six.string_types) and os.path.isfile(MaskFilePath):
+    if isinstance(MaskFilePath, str) and os.path.isfile(MaskFilePath):
       mask = sitk.ReadImage(MaskFilePath)
     elif isinstance(MaskFilePath, sitk.SimpleITK.Image):
       mask = MaskFilePath
@@ -442,7 +441,7 @@ class RadiomicsFeatureExtractor:
         for feature in featureNames:
           shapeClass.enableFeatureByName(feature)
 
-      for (featureName, featureValue) in six.iteritems(shapeClass.execute()):
+      for (featureName, featureValue) in shapeClass.execute().items():
         newFeatureName = 'original_%s_%s' % (shape_type, featureName)
         featureVector[newFeatureName] = featureValue
 
@@ -500,7 +499,7 @@ class RadiomicsFeatureExtractor:
     enabledFeatures = self.enabledFeatures
 
     # Calculate feature classes
-    for featureClassName, featureNames in six.iteritems(enabledFeatures):
+    for featureClassName, featureNames in enabledFeatures.items():
       # Handle calculation of shape features separately
       if featureClassName.startswith('shape'):
         continue
@@ -514,7 +513,7 @@ class RadiomicsFeatureExtractor:
           for feature in featureNames:
             featureClass.enableFeatureByName(feature)
 
-        for (featureName, featureValue) in six.iteritems(featureClass.execute()):
+        for (featureName, featureValue) in featureClass.execute().items():
           newFeatureName = '%s_%s_%s' % (imageTypeName, featureClassName, featureName)
           featureVector[newFeatureName] = featureValue
 

--- a/radiomics/firstorder.py
+++ b/radiomics/firstorder.py
@@ -1,5 +1,4 @@
 import numpy
-from six.moves import range
 
 from radiomics import base, cMatrices, deprecated
 

--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -1,5 +1,4 @@
 import numpy
-from six.moves import range
 
 from radiomics import base, cMatrices, deprecated
 

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -1,5 +1,4 @@
 import numpy
-from six.moves import range
 
 from radiomics import base, cMatrices
 

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -5,8 +5,6 @@ import logging
 import numpy
 import pywt
 import SimpleITK as sitk
-import six
-from six.moves import range
 
 logger = logging.getLogger(__name__)
 
@@ -538,7 +536,7 @@ def resampleImage(imageNode, maskNode, **kwargs):
               maskSpacing, maskSize, resampledPixelSpacing, newSize)
 
   try:
-    if isinstance(interpolator, six.string_types):
+    if isinstance(interpolator, str):
       interpolator = getattr(sitk, interpolator)
   except Exception:
     logger.warning('interpolator "%s" not recognized, using sitkBSpline', interpolator)
@@ -868,7 +866,7 @@ def _swt3(inputImage, axes, **kwargs):  # Stationary Wavelet Transform 3D
     data = dec['a' * len(axes)].copy()
 
     dec_im = {}  # initialize empty dict
-    for decName, decImage in six.iteritems(dec):
+    for decName, decImage in dec.items():
       # Returning the approximiation is done only for the last loop,
       # and is handled separately below (by building it from `data`)
       # There for, skip it here

--- a/radiomics/schemas/schemaFuncs.py
+++ b/radiomics/schemas/schemaFuncs.py
@@ -1,5 +1,4 @@
 import pywt
-import six
 
 from radiomics import getFeatureClasses, getImageTypes
 
@@ -7,7 +6,7 @@ featureClasses = getFeatureClasses()
 imageTypes = getImageTypes()
 
 def checkWavelet(value, rule_obj, path):
-  if not isinstance(value, six.string_types):
+  if not isinstance(value, str):
     raise TypeError('Wavelet not expected type (str)')
   wavelist = pywt.wavelist()
   if value not in wavelist:
@@ -18,7 +17,7 @@ def checkWavelet(value, rule_obj, path):
 def checkInterpolator(value, rule_obj, path):
   if value is None:
     return True
-  if isinstance(value, six.string_types):
+  if isinstance(value, str):
     enum = {'sitkNearestNeighbor',
             'sitkLinear',
             'sitkBSpline',
@@ -42,7 +41,7 @@ def checkInterpolator(value, rule_obj, path):
 def checkWeighting(value, rule_obj, path):
   if value is None:
     return True
-  elif isinstance(value, six.string_types):
+  elif isinstance(value, str):
     enum = ['euclidean', 'manhattan', 'infinity', 'no_weighting']
     if value not in enum:
       raise ValueError('WeightingNorm value "%s" not valid, possible values: %s' % (value, enum))
@@ -55,7 +54,7 @@ def checkFeatureClass(value, rule_obj, path):
   global featureClasses
   if value is None:
     raise TypeError('featureClass dictionary cannot be None value')
-  for className, features in six.iteritems(value):
+  for className, features in value.items():
     if className not in featureClasses.keys():
       raise ValueError(
         'Feature Class %s is not recognized. Available feature classes are %s' % (className, list(featureClasses.keys())))

--- a/radiomics/scripts/__init__.py
+++ b/radiomics/scripts/__init__.py
@@ -13,7 +13,6 @@ import threading
 import numpy
 from pykwalify.compat import yaml
 import pykwalify.core
-import six.moves
 
 import radiomics
 import radiomics.featureextractor
@@ -65,7 +64,7 @@ class PyRadiomicsCommandLine:
                                  'settings possible. N.B. Only works for customization\n'
                                  'type 3 ("setting").')
     inputGroup.add_argument('--jobs', '-j', metavar='N', type=int, default=1,
-                            choices=six.moves.range(1, cpu_count() + 1),
+                            choices=range(1, cpu_count() + 1),
                             help='(Batch mode only) Specifies the number of threads to use for\n'
                                  'parallel processing. This is applied at the case level;\n'
                                  'i.e. 1 thread per case. Actual number of workers used is\n'
@@ -325,7 +324,7 @@ class PyRadiomicsCommandLine:
           writer.writeheader()
         writer.writerow(case)  # if skip_nans is enabled, nan-values are written as empty strings
       elif self.args.format == 'txt':
-        for k, v in six.iteritems(case):
+        for k, v in case.items():
           self.args.out.write('Case-%d_%s: %s\n' % (case_idx, k, v))
 
     # JSON dump of cases is handled outside of the loop, otherwise the resultant document would be invalid.

--- a/radiomics/scripts/segment.py
+++ b/radiomics/scripts/segment.py
@@ -6,7 +6,6 @@ import os
 import threading
 
 import SimpleITK as sitk
-import six
 
 import radiomics
 
@@ -27,8 +26,8 @@ def extractSegment(case_idx, case, extractor, **kwargs):
     # Output already generated, load result (prevents re-extraction in case of interrupted process)
     with open(filename, 'r') as outputFile:
       reader = csv.reader(outputFile)
-      headers = six.next(reader)
-      values = six.next(reader)
+      headers = next(reader)
+      values = next(reader)
       feature_vector = OrderedDict(zip(headers, values))
 
     caseLogger.info('Patient %s already processed, reading results...', case_idx)
@@ -60,10 +59,10 @@ def _extractFeatures(case_idx, case, extractor):
     imageFilepath = case['Image']  # Required
     maskFilepath = case['Mask']  # Required
     label = case.get('Label', None)  # Optional
-    if isinstance(label, six.string_types):
+    if isinstance(label, str):
       label = int(label)
     label_channel = case.get('Label_channel', None)  # Optional
-    if isinstance(label_channel, six.string_types):
+    if isinstance(label_channel, str):
       label_channel = int(label_channel)
 
     # Extract features

--- a/radiomics/scripts/voxel.py
+++ b/radiomics/scripts/voxel.py
@@ -5,7 +5,6 @@ import os
 import threading
 
 import SimpleITK as sitk
-import six
 
 import radiomics
 
@@ -35,10 +34,10 @@ def extractVoxel(case_idx, case, extractor, **kwargs):
     imageFilepath = case['Image']  # Required
     maskFilepath = case['Mask']  # Required
     label = case.get('Label', None)  # Optional
-    if isinstance(label, six.string_types):
+    if isinstance(label, str):
       label = int(label)
     label_channel = case.get('Label_channel', None)  # Optional
-    if isinstance(label_channel, six.string_types):
+    if isinstance(label_channel, str):
       label_channel = int(label_channel)
 
     # Extract features

--- a/tests/addTest.py
+++ b/tests/addTest.py
@@ -1,8 +1,6 @@
 import argparse
 import logging
 
-import six
-
 import radiomics
 from radiomics import featureextractor
 from testUtils import RadiomicsTestUtils
@@ -55,7 +53,7 @@ def main(argv=None):
     configuration = {}
     baselines = {}
 
-    for k, v in six.iteritems(featurevector):
+    for k, v in featurevector.items():
       if 'diagnostics' in k:
         configuration[k] = v
       else:

--- a/tests/add_baseline.py
+++ b/tests/add_baseline.py
@@ -4,7 +4,6 @@ import sys
 
 import numpy
 import SimpleITK as sitk
-import six
 
 from radiomics import generalinfo, getFeatureClasses, getTestCase, imageoperations
 from testUtils import PyRadiomicsBaseline, RadiomicsTestUtils
@@ -24,7 +23,7 @@ class AddBaseline:
     self.baselineDir = os.path.join(dataDir, "baseline")
 
   def generate_scenarios(self):
-    for className, featureClass in six.iteritems(self.featureClasses):
+    for className, featureClass in self.featureClasses.items():
       if not os.path.exists(os.path.join(self.baselineDir, 'baseline_%s.csv' % className)):
         self.logger.debug('generate_scenarios: featureClass = %s', className)
         for test in self.testCases:
@@ -57,11 +56,11 @@ class AddBaseline:
     self.new_baselines[featureClassName].configuration[test].update(versions)
 
     self.new_baselines[featureClassName].baseline[test] = {'%s_%s_%s' % (imageTypeName, featureClassName, key): val
-                                                           for key, val in six.iteritems(featureClass.featureValues)}
+                                                           for key, val in featureClass.featureValues.items()}
 
   def run(self, featureClass=None):
     current_baseline = self.testUtils._baseline
-    config = current_baseline[current_baseline.keys()[0]].configuration
+    config = current_baseline[list(current_baseline.keys())[0]].configuration
     self.new_baselines = {}
     if featureClass is None:
       for test, newClass in self.generate_scenarios():

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -6,7 +6,6 @@ import os
 
 import numpy
 import SimpleITK as sitk
-import six
 
 from radiomics import featureextractor, getTestCase, imageoperations
 
@@ -302,9 +301,9 @@ class PyRadiomicsBaseline:
     new_baseline = cls(featureClassName)
     new_baseline.logger.debug('Reading baseline for class %s', new_baseline.cls)
 
-    with open(baselineFile, 'r' if six.PY3 else 'rb') as baselineReader:
+    with open(baselineFile, 'r') as baselineReader:
       csvReader = csv.reader(baselineReader)
-      tests = six.next(csvReader)[1:]
+      tests = next(csvReader)[1:]
 
       for case in tests:
         new_baseline.configuration[case] = {}

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,7 +1,5 @@
 import logging
 
-import six
-
 from radiomics import getFeatureClasses
 
 featureClasses = getFeatureClasses()
@@ -16,7 +14,7 @@ class TestDocStrings:
   @staticmethod
   def generate_scenarios():
     global featureClasses
-    for featureClassName, featureClass in six.iteritems(featureClasses):
+    for featureClassName, featureClass in featureClasses.items():
       logging.info('generate_scenarios %s', featureClassName)
       doc = featureClass.__doc__
       assert (doc is not None)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-import six
-
 from radiomics import getFeatureClasses
 from testUtils import RadiomicsTestUtils
 
@@ -40,7 +38,7 @@ class TestFeatures:
         # Get a list of all features for current class
         featureNames = featureClasses[featureClassName].getFeatureNames()
         # Get a list of all non-deprecated features
-        activeFeatures = set([f for (f, deprecated) in six.iteritems(featureNames) if not deprecated])
+        activeFeatures = set([f for (f, deprecated) in featureNames.items() if not deprecated])
         # Check if all active features have a baseline (exclude deprecated features from this set)
         if len(activeFeatures - uniqueFeatures) > 0:
           raise AssertionError('Missing baseline for active features %s', activeFeatures - uniqueFeatures)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 import numpy
-import six
 
 from radiomics import getFeatureClasses, testCases
 from testUtils import RadiomicsTestUtils
@@ -26,7 +25,7 @@ class TestMatrices:
     for testCase in testCases:
       if testCase.startswith('test'):
         continue
-      for className, featureClass in six.iteritems(featureClasses):
+      for className, featureClass in featureClasses.items():
         assert featureClass is not None
         if "_calculateMatrix" in dir(featureClass):
           logging.debug('generate_scenarios: featureClass = %s', className)


### PR DESCRIPTION
This commit replaces `six.iteritems()` with Python 3's native `dict.items()` for iterating over dictionary items. The now unnecessary `six` import is removed, aligning the codebase with modern Python practices and enhancing maintainability.

Support for Python2 was removed many years ago.  Clean up the codebase by removing the conditional behaviors encoded with six.