### PR TITLE
COMP: Limit to environments of python3.9 and python3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
+#NOTE: numpy 2.0 is the last to support python 3.9-3.12
+#NOTE: numpy 2.1 is only supported by 3.10 and greater
 [build-system]
-requires = ["scikit-build-core>=0.11.2", "numpy"]
+requires = ["scikit-build-core>=0.11.2", "numpy==2.0"]
 build-backend = "scikit_build_core.build"
 
 
@@ -10,7 +12,9 @@ authors = [
 ]
 description = "Radiomics features library for python"
 readme = "README.md"
-requires-python =">=3.9"
+# Currently only supports python 3.9 and 3.10
+# A segmentation fault occurs with python 3.11, 3.12, 3.13
+requires-python =">=3.9,<3.11"
 license = { file = "LICENSE.txt"}
 keywords = [ "radiomics", "cancerimaging", "medicalresearch", "computationalimaging" ]
 classifiers = [
@@ -23,12 +27,11 @@ classifiers = [
     'Programming Language :: C',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering :: Bio-Informatics'
 ]
 dynamic = ["version"]
 dependencies = [
-    "numpy",
+    "numpy==2.0",
     "SimpleITK ==2.4.1",
     "PyWavelets >= 1.6.0",
     "pykwalify >= 1.6.0"


### PR DESCRIPTION
Testing has confirmed that python3.11 and 3.12 both cause segmentation faults when loading the locally built radiomics/src c-modules.