### PR TITLE
Remove versioneer

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ show-source: True
 # Maximum cyclomatic complexity allowed
 max-complexity: 14
 format: pylint
-exclude: .git,.idea,.eggs,__pycache__,.tox,docs/conf.py,_skbuild,build,versioneer.py
+exclude: .git,.idea,.eggs,__pycache__,.tox,docs/conf.py,_skbuild,build
 ignore:
     # cycolmatic complexity check
     C901,

--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -342,7 +342,7 @@ _imageTypes = None
 getFeatureClasses()
 getImageTypes()
 
-# 5. Set the version using the versioneer scripts
+# 5. Set the version dynamically using setuptools-scm
 from ._version import version as __version__
 
 __all__ = ["__version__"]

--- a/radiomics/_version.pyi
+++ b/radiomics/_version.pyi
@@ -1,4 +1,0 @@
-from __future__ import annotations
-
-version: str
-version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]


### PR DESCRIPTION
versioneer is no longer used for version management.     setuptools-scm is now used.